### PR TITLE
8373632: Some sound tests failing in CI due to lack of sound key

### DIFF
--- a/test/jdk/javax/sound/midi/Sequencer/Looping.java
+++ b/test/jdk/javax/sound/midi/Sequencer/Looping.java
@@ -36,7 +36,7 @@ import javax.sound.midi.Track;
  * @test
  * @bug 4204105
  * @summary RFE: add loop() method(s) to Sequencer
- * @key intermittent
+ * @key sound
  */
 public class Looping {
 

--- a/test/jdk/javax/sound/sampled/Clip/IsRunningHang.java
+++ b/test/jdk/javax/sound/sampled/Clip/IsRunningHang.java
@@ -36,6 +36,7 @@ import javax.sound.sampled.LineUnavailableException;
 /**
  * @test
  * @bug 8156169
+ * @key sound
  * @run main/othervm/timeout=300 IsRunningHang
  */
 public final class IsRunningHang {

--- a/test/jdk/javax/sound/sampled/DataLine/LongFramePosition.java
+++ b/test/jdk/javax/sound/sampled/DataLine/LongFramePosition.java
@@ -29,6 +29,7 @@ import javax.sound.sampled.SourceDataLine;
 /**
  * @test
  * @bug 5049129
+ * @key sound
  * @summary DataLine.getLongFramePosition
  */
 public class LongFramePosition {

--- a/test/jdk/javax/sound/sampled/DirectAudio/bug6372428.java
+++ b/test/jdk/javax/sound/sampled/DirectAudio/bug6372428.java
@@ -31,6 +31,7 @@ import javax.sound.sampled.TargetDataLine;
 /*
  * @test
  * @bug 6372428
+ * @key sound
  * @summary playback and capture doesn't interrupt after terminating thread that
  *          calls start()
  * @run main bug6372428


### PR DESCRIPTION
Add @key sound annotation to 4 jtreg tests that were failing in CI due to missing sound permissions. Without this keyword, these tests can run on systems lacking sound access, causing hangs on macOS 26 (due to a macOS bug that will be fixed in a future update).

3 tests: New failures introduced when de-problem-listing without adding the required sound keyword
1 test: Previously observed failure that now passes consistently (40+ runs) with the sound keyword added

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8373632](https://bugs.openjdk.org/browse/JDK-8373632) needs maintainer approval

### Issue
 * [JDK-8373632](https://bugs.openjdk.org/browse/JDK-8373632): Some sound tests failing in CI due to lack of sound key (**Bug** - P4 - Approved)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/8.diff">https://git.openjdk.org/jdk26u/pull/8.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/8#issuecomment-3716126436)
</details>
