### PR TITLE
8373448: jpackage: StackOverflowError when processing a very long argument

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/cli/StandardOption.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/cli/StandardOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -727,8 +727,15 @@ public final class StandardOption {
         //
 
         // regexp for parsing args (for example, for additional launchers)
-        private static Pattern pattern = Pattern.compile(
-              "(?:(?:([\"'])(?:\\\\\\1|.)*?(?:\\1|$))|(?:\\\\[\"'\\s]|[^\\s]))++");
+        private static Pattern PATTERN = Pattern.compile(String.format(
+                "(?:(?:%s|%s)|(?:\\\\[\"'\\s]|\\S))++",
+                createPatternComponent('\''),
+                createPatternComponent('\"')));
+
+        private static String createPatternComponent(char quoteChar) {
+            var str = Character.toString(quoteChar);
+            return String.format("(?:%s(?:\\\\%s|[^%s])*+(?:%s|$))", str, str, str, str);
+        }
 
         static List<String> getArgumentList(String inputString) {
             Objects.requireNonNull(inputString);
@@ -741,7 +748,7 @@ public final class StandardOption {
             // The "pattern" regexp attempts to abide to the rule that
             // strings are delimited by whitespace unless surrounded by
             // quotes, then it is anything (including spaces) in the quotes.
-            Matcher m = pattern.matcher(inputString);
+            Matcher m = PATTERN.matcher(inputString);
             while (m.find()) {
                 String s = inputString.substring(m.start(), m.end()).trim();
                 // Ensure we do not have an empty string. trim() will take care of

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/StandardOptionTest.java
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/StandardOptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -341,9 +341,33 @@ public class StandardOptionTest extends JUnitAdapter.TestSrcInitializer {
                 Arguments.of("abc", List.of("abc")),
                 Arguments.of("a b c", List.of("a", "b", "c")),
                 Arguments.of("a=10 -Dorg.acme.name='John Smith' c=\\\"foo\\\"", List.of("a=10", "-Dorg.acme.name=John Smith", "c=\"foo\"")),
+                Arguments.of("  foo \"a b c\" v=' John Smith ' 'H e ll o' ", List.of("foo", "a b c", "v= John Smith ", "H e ll o")),
                 Arguments.of("\"\"", List.of("")),
                 Arguments.of(" ", List.of()),
-                Arguments.of("", List.of())
+                Arguments.of("   ", List.of()),
+                Arguments.of(" foo  ", List.of("foo")),
+                Arguments.of("", List.of()),
+                Arguments.of("'fo\"o'\\ buzz \"b a r\"", List.of("fo\"o\\ buzz", "b a r")),
+                Arguments.of("a\\ 'b\"c'\\ d", List.of("a\\ b\"c\\ d")),
+                Arguments.of("\"a 'bc' d\"", List.of("a 'bc' d")),
+                Arguments.of("\'a 'bc' d\'", List.of("a bc d")),
+                Arguments.of("\"a \\'bc\\' d\"", List.of("a 'bc' d")),
+                Arguments.of("\'a \\'bc\\' d\'", List.of("a 'bc' d")),
+                Arguments.of("'a b c' 'd e f'", List.of("a b c", "d e f")),
+                Arguments.of("'a b c' \"'d e f'  h", List.of("a b c", "'d e f'  h")),
+                Arguments.of("'a b c' \"'d e f' \t  ", List.of("a b c", "'d e f'")),
+                Arguments.of(" a='' '' \t '\\'\\'' \"\" \"\\\"\\\"\" ", List.of("a=", "", "\'\'", "", "\"\"")),
+                Arguments.of("' \'foo '", List.of(" foo", "")),
+                Arguments.of("' \'foo ' bar", List.of(" foo", " bar")),
+                Arguments.of("' \'foo\\ '", List.of(" foo\\ ")),
+                Arguments.of("'fo\"o buzz \"b a r\"", List.of("fo\"o buzz \"b a r\"")),
+                Arguments.of("'", List.of("")),
+                Arguments.of("' f g  ", List.of(" f g")),
+                Arguments.of("' f g", List.of(" f g")),
+                Arguments.of("'\\'", List.of("'")),
+                Arguments.of("'\\'  ", List.of("'")),
+                Arguments.of("'\\' a ", List.of("' a")),
+                Arguments.of("\"" + "\\\"".repeat(10000) + "A", List.of("\"".repeat(10000) + "A"))
         );
     }
 


### PR DESCRIPTION
Clean backport of the https://github.com/openjdk/jdk/pull/29104 PR

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8373448](https://bugs.openjdk.org/browse/JDK-8373448) needs maintainer approval

### Issue
 * [JDK-8373448](https://bugs.openjdk.org/browse/JDK-8373448): jpackage: StackOverflowError when processing a very long argument (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/13/head:pull/13` \
`$ git checkout pull/13`

Update a local copy of the PR: \
`$ git checkout pull/13` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/13/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13`

View PR using the GUI difftool: \
`$ git pr show -t 13`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/13.diff">https://git.openjdk.org/jdk26u/pull/13.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/13#issuecomment-3751908000)
</details>
