### PR TITLE
8373793: TestDynamicStore.java '/manual' disables use of '/timeout'

### DIFF
--- a/test/jdk/sun/security/krb5/config/native/TestDynamicStore.java
+++ b/test/jdk/sun/security/krb5/config/native/TestDynamicStore.java
@@ -27,7 +27,7 @@
  * @summary SCDynamicStoreConfig works
  * @modules java.security.jgss/sun.security.krb5
  * @library /test/lib
- * @run main/manual/native/timeout=180 TestDynamicStore
+ * @run main/manual/native TestDynamicStore
  * @requires (os.family == "mac")
  */
 


### PR DESCRIPTION
Ran the test manually on MacOS using sudo and the test passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8373793](https://bugs.openjdk.org/browse/JDK-8373793) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8373793](https://bugs.openjdk.org/browse/JDK-8373793): TestDynamicStore.java '/manual' disables use of '/timeout' (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/15.diff">https://git.openjdk.org/jdk26u/pull/15.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/15#issuecomment-3758015810)
</details>
