### PR TITLE
8370489: Some compiler tests miss the @key randomness

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/TestMergeStores.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMergeStores.java
@@ -34,6 +34,7 @@ import java.util.Random;
 /*
  * @test
  * @bug 8318446 8331054 8331311 8335392 8347405
+ * @key randomness
  * @summary Test merging of consecutive stores
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
@@ -43,6 +44,7 @@ import java.util.Random;
 /*
  * @test
  * @bug 8318446 8331054 8331311 8335392 8347405
+ * @key randomness
  * @summary Test merging of consecutive stores
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
@@ -52,6 +54,7 @@ import java.util.Random;
 /*
  * @test
  * @bug 8318446 8331054 8331311 8335392 8348959 8351414
+ * @key randomness
  * @summary Test merging of consecutive stores
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/c2/TestMergeStoresMemorySegment.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMergeStoresMemorySegment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.lang.foreign.*;
 /*
  * @test id=byte-array
  * @bug 8335392
+ * @key randomness
  * @summary Test MergeStores optimization for MemorySegment
  * @library /test/lib /
  * @run driver compiler.c2.TestMergeStoresMemorySegment ByteArray
@@ -42,6 +43,7 @@ import java.lang.foreign.*;
 /*
  * @test id=char-array
  * @bug 8335392
+ * @key randomness
  * @summary Test MergeStores optimization for MemorySegment
  * @library /test/lib /
  * @run driver compiler.c2.TestMergeStoresMemorySegment CharArray
@@ -50,6 +52,7 @@ import java.lang.foreign.*;
 /*
  * @test id=short-array
  * @bug 8335392
+ * @key randomness
  * @summary Test MergeStores optimization for MemorySegment
  * @library /test/lib /
  * @run driver compiler.c2.TestMergeStoresMemorySegment ShortArray
@@ -58,6 +61,7 @@ import java.lang.foreign.*;
 /*
  * @test id=int-array
  * @bug 8335392
+ * @key randomness
  * @summary Test MergeStores optimization for MemorySegment
  * @library /test/lib /
  * @run driver compiler.c2.TestMergeStoresMemorySegment IntArray
@@ -66,6 +70,7 @@ import java.lang.foreign.*;
 /*
  * @test id=long-array
  * @bug 8335392
+ * @key randomness
  * @summary Test MergeStores optimization for MemorySegment
  * @library /test/lib /
  * @run driver compiler.c2.TestMergeStoresMemorySegment LongArray
@@ -74,6 +79,7 @@ import java.lang.foreign.*;
 /*
  * @test id=float-array
  * @bug 8335392
+ * @key randomness
  * @summary Test MergeStores optimization for MemorySegment
  * @library /test/lib /
  * @run driver compiler.c2.TestMergeStoresMemorySegment FloatArray
@@ -82,6 +88,7 @@ import java.lang.foreign.*;
 /*
  * @test id=double-array
  * @bug 8335392
+ * @key randomness
  * @summary Test MergeStores optimization for MemorySegment
  * @library /test/lib /
  * @run driver compiler.c2.TestMergeStoresMemorySegment DoubleArray
@@ -90,6 +97,7 @@ import java.lang.foreign.*;
 /*
  * @test id=byte-buffer
  * @bug 8335392
+ * @key randomness
  * @summary Test MergeStores optimization for MemorySegment
  * @library /test/lib /
  * @run driver compiler.c2.TestMergeStoresMemorySegment ByteBuffer
@@ -98,6 +106,7 @@ import java.lang.foreign.*;
 /*
  * @test id=byte-buffer-direct
  * @bug 8335392
+ * @key randomness
  * @summary Test MergeStores optimization for MemorySegment
  * @library /test/lib /
  * @run driver compiler.c2.TestMergeStoresMemorySegment ByteBufferDirect
@@ -106,6 +115,7 @@ import java.lang.foreign.*;
 /*
  * @test id=native
  * @bug 8335392
+ * @key randomness
  * @summary Test MergeStores optimization for MemorySegment
  * @library /test/lib /
  * @run driver compiler.c2.TestMergeStoresMemorySegment Native

--- a/test/hotspot/jtreg/compiler/c2/TestMinMaxSubword.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMinMaxSubword.java
@@ -31,6 +31,7 @@ import java.util.Random;
 /*
  * @test
  * @bug 8294816
+ * @key randomness
  * @summary Test Math.min/max vectorization miscompilation for integer subwords
  * @library /test/lib /
  * @requires vm.compiler2.enabled

--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestFloat16Replicate.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestFloat16Replicate.java
@@ -23,6 +23,7 @@
 /**
 * @test
 * @bug 8361582
+* @key randomness
 * @summary Ensure the correct backend replicate node is being generated for
 *          half precision float constants on >16B SVE machines
 * @modules jdk.incubator.vector

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModDNodeTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModDNodeTests.java
@@ -30,6 +30,7 @@ import compiler.lib.ir_framework.*;
 /*
  * @test
  * @bug 8345766
+ * @key randomness
  * @summary Test that Ideal transformations of ModDNode are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.ModDNodeTests

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModFNodeTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModFNodeTests.java
@@ -30,6 +30,7 @@ import compiler.lib.ir_framework.*;
 /*
  * @test
  * @bug 8345766
+ * @key randomness
  * @summary Test that Ideal transformations of ModFNode are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.ModFNodeTests

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModINodeIdealizationTests.java
@@ -32,6 +32,7 @@ import compiler.lib.ir_framework.*;
 /*
  * @test
  * @bug 8332268
+ * @key randomness
  * @summary Test that Ideal transformations of ModINode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.ModINodeIdealizationTests

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModLNodeIdealizationTests.java
@@ -32,6 +32,7 @@ import compiler.lib.ir_framework.*;
 /*
  * @test
  * @bug 8267265
+ * @key randomness
  * @summary Test that Ideal transformations of ModLNode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.ModLNodeIdealizationTests

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestMulNodeIdealization.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestMulNodeIdealization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import jdk.test.lib.Utils;
 /*
  * @test
  * @bug 8291336
+ * @key randomness
  * @summary Test that transformation of multiply-by-2 is appropriately turned into additions.
  * @library /test/lib /
  * @requires vm.compiler2.enabled

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestShiftAndMask.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestShiftAndMask.java
@@ -31,6 +31,7 @@ import java.util.Objects;
 /*
  * @test
  * @bug 8277850 8278949 8285793 8346664
+ * @key randomness
  * @summary C2: optimize mask checks in counted loops
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestShiftAndMask

--- a/test/hotspot/jtreg/compiler/c2/irTests/UDivINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/UDivINodeIdealizationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import compiler.lib.ir_framework.*;
 /*
  * @test
  * @bug 8332268
+ * @key randomness
  * @summary Test that Ideal transformations of UDivINode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.UDivINodeIdealizationTests

--- a/test/hotspot/jtreg/compiler/c2/irTests/UDivLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/UDivLNodeIdealizationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import compiler.lib.ir_framework.*;
 /*
  * @test
  * @bug 8332268
+ * @key randomness
  * @summary Test that Ideal transformations of UDivLNode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.UDivLNodeIdealizationTests

--- a/test/hotspot/jtreg/compiler/c2/irTests/UModINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/UModINodeIdealizationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import compiler.lib.ir_framework.*;
 /*
  * @test
  * @bug 8332268
+ * @key randomness
  * @summary Test that Ideal transformations of UModINode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.UModINodeIdealizationTests

--- a/test/hotspot/jtreg/compiler/c2/irTests/UModLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/UModLNodeIdealizationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import compiler.lib.ir_framework.*;
 /*
  * @test
  * @bug 8332268
+ * @key randomness
  * @summary Test that Ideal transformations of UModLNode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.UModLNodeIdealizationTests

--- a/test/hotspot/jtreg/compiler/controldependency/TestDivDependentOnMainLoopGuard.java
+++ b/test/hotspot/jtreg/compiler/controldependency/TestDivDependentOnMainLoopGuard.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8349139
+ * @key randomness
  * @summary C2: Div looses dependency on condition that guarantees divisor not null in counted loop
  * @library /test/lib /
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestDivDependentOnMainLoopGuard::*

--- a/test/hotspot/jtreg/compiler/igvn/ExpressionFuzzer.java
+++ b/test/hotspot/jtreg/compiler/igvn/ExpressionFuzzer.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8359412
+ * @key randomness
  * @summary Use the template framework library to generate random expressions.
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/float16/TestFloat16MaxMinSpecialValues.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/TestFloat16MaxMinSpecialValues.java
@@ -30,6 +30,7 @@ import jdk.test.lib.*;
 /**
  * @test
  * @bug 8352585
+ * @key randomness
  * @library /test/lib /
  * @summary Add special case handling for Float16.max/min x86 backend
  * @modules jdk.incubator.vector

--- a/test/hotspot/jtreg/compiler/loopopts/InvariantCodeMotionReassociateAddSub.java
+++ b/test/hotspot/jtreg/compiler/loopopts/InvariantCodeMotionReassociateAddSub.java
@@ -31,6 +31,7 @@ import java.util.Random;
 /*
  * @test
  * @bug 8323220
+ * @key randomness
  * @summary Test loop invariant code motion of add/sub through reassociation
  * @library /test/lib /
  * @run driver compiler.c2.loopopts.InvariantCodeMotionReassociateAddSub

--- a/test/hotspot/jtreg/compiler/loopopts/InvariantCodeMotionReassociateCmp.java
+++ b/test/hotspot/jtreg/compiler/loopopts/InvariantCodeMotionReassociateCmp.java
@@ -31,6 +31,7 @@ import java.util.Random;
 /*
  * @test
  * @bug 8323220
+ * @key randomness
  * @summary Test loop invariant code motion for cmp nodes through reassociation
  * @library /test/lib /
  * @run driver compiler.c2.loopopts.InvariantCodeMotionReassociateCmp

--- a/test/hotspot/jtreg/compiler/loopopts/parallel_iv/TestParallelIvInIntCountedLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/parallel_iv/TestParallelIvInIntCountedLoop.java
@@ -32,6 +32,7 @@ import java.util.Random;
 /**
  * @test
  * @bug 8328528
+ * @key randomness
  * @summary test the long typed parallel iv replacing transformation for int counted loop
  * @library /test/lib /
  * @requires vm.compiler2.enabled

--- a/test/hotspot/jtreg/compiler/loopopts/superword/MinMaxRed_Int.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/MinMaxRed_Int.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 8302673
+ * @key randomness
  * @summary [SuperWord] MaxReduction and MinReduction should vectorize for int
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.MinMaxRed_Int

--- a/test/hotspot/jtreg/compiler/loopopts/superword/ReductionPerf.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/ReductionPerf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8074981 8302652
+ * @key randomness
  * @summary Test SuperWord Reduction Perf.
  * @library /test/lib /
  * @run main/othervm -Xbatch

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestAliasing.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestAliasing.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8324751
+ * @key randomness
  * @summary Test Speculative Aliasing checks in SuperWord
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestAliasing nCOH_nAV_ySAC

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestAlignVector.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestAlignVector.java
@@ -36,6 +36,7 @@ import java.nio.ByteOrder;
 /*
  * @test id=NoAlignVector
  * @bug 8310190
+ * @key randomness
  * @summary Test AlignVector with various loop init, stride, scale, invar, etc.
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestCompatibleUseDefTypeSize.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestCompatibleUseDefTypeSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.nio.ByteOrder;
 /*
  * @test
  * @bug 8325155
+ * @key randomness
  * @summary Test some cases that vectorize after the removal of the alignment boundaries code.
  *          Now, we instead check if use-def connections have compatible type size.
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
@@ -24,6 +24,7 @@
 /*
  * @test id=vanilla-A
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @library /test/lib /
  * @compile ../../lib/ir_framework/TestFramework.java
@@ -33,6 +34,7 @@
 /*
  * @test id=vanilla-U
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @library /test/lib /
  * @compile ../../lib/ir_framework/TestFramework.java
@@ -42,6 +44,7 @@
 /*
  * @test id=sse4-v016-A
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -54,6 +57,7 @@
 /*
  * @test id=sse4-v016-U
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -66,6 +70,7 @@
 /*
  * @test id=sse4-v008-A
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -78,6 +83,7 @@
 /*
  * @test id=sse4-v008-U
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -102,6 +108,7 @@
 /*
  * @test id=sse4-v004-U
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -114,6 +121,7 @@
 /*
  * @test id=avx1-v032-A
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -126,6 +134,7 @@
 /*
  * @test id=avx1-v032-U
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -138,6 +147,7 @@
 /*
  * @test id=avx1-v016-A
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -150,6 +160,7 @@
 /*
  * @test id=avx1-v016-U
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -162,6 +173,7 @@
 /*
  * @test id=avx2-v032-A
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -174,6 +186,7 @@
 /*
  * @test id=avx2-v032-U
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -186,6 +199,7 @@
 /*
  * @test id=avx2-v016-A
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -198,6 +212,7 @@
 /*
  * @test id=avx2-v016-U
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -210,6 +225,7 @@
 /*
  * @test id=avx512-v064-A
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -222,6 +238,7 @@
 /*
  * @test id=avx512-v064-U
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -234,6 +251,7 @@
 /*
  * @test id=avx512-v032-A
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -246,6 +264,7 @@
 /*
  * @test id=avx512-v032-U
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -258,6 +277,7 @@
 /*
  * @test id=avx512bw-v064-A
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -270,6 +290,7 @@
 /*
  * @test id=avx512bw-v064-U
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -282,6 +303,7 @@
 /*
  * @test id=avx512bw-v032-A
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -294,6 +316,7 @@
 /*
  * @test id=avx512bw-v032-U
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -306,6 +329,7 @@
 /*
  * @test id=vec-v064-A
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch!="x86" & os.arch!="i386" & os.arch!="amd64" & os.arch!="x86_64")
@@ -317,6 +341,7 @@
 /*
  * @test id=vec-v064-U
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch!="x86" & os.arch!="i386" & os.arch!="amd64" & os.arch!="x86_64")
@@ -328,6 +353,7 @@
 /*
  * @test id=vec-v032-A
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch!="x86" & os.arch!="i386" & os.arch!="amd64" & os.arch!="x86_64")
@@ -339,6 +365,7 @@
 /*
  * @test id=vec-v032-U
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch!="x86" & os.arch!="i386" & os.arch!="amd64" & os.arch!="x86_64")
@@ -350,6 +377,7 @@
 /*
  * @test id=vec-v016-A
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch!="x86" & os.arch!="i386" & os.arch!="amd64" & os.arch!="x86_64")
@@ -361,6 +389,7 @@
 /*
  * @test id=vec-v016-U
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch!="x86" & os.arch!="i386" & os.arch!="amd64" & os.arch!="x86_64")
@@ -372,6 +401,7 @@
 /*
  * @test id=vec-v008-A
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch!="x86" & os.arch!="i386" & os.arch!="amd64" & os.arch!="x86_64")
@@ -383,6 +413,7 @@
 /*
  * @test id=vec-v008-U
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch!="x86" & os.arch!="i386" & os.arch!="amd64" & os.arch!="x86_64")
@@ -394,6 +425,7 @@
 /*
  * @test id=vec-v004-A
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch!="x86" & os.arch!="i386" & os.arch!="amd64" & os.arch!="x86_64")
@@ -405,6 +437,7 @@
 /*
  * @test id=vec-v004-U
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch!="x86" & os.arch!="i386" & os.arch!="amd64" & os.arch!="x86_64")

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestEquivalentInvariants.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestEquivalentInvariants.java
@@ -35,6 +35,7 @@ import java.lang.foreign.*;
 /*
  * @test
  * @bug 8343685 8331659
+ * @key randomness
  * @summary Test vectorization with various invariants that are equivalent, but not trivially so,
  *          i.e. where the invariants have the same summands, but in a different order.
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegment.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegment.java
@@ -34,6 +34,7 @@ import java.lang.foreign.*;
 /*
  * @test id=byte-array
  * @bug 8329273
+ * @key randomness
  * @summary Test vectorization of loops over MemorySegment
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestMemorySegment ByteArray

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegmentUnalignedAddress.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegmentUnalignedAddress.java
@@ -35,6 +35,7 @@ import java.lang.foreign.*;
 /*
  * @test id=byte-buffer-direct
  * @bug 8323582
+ * @key randomness
  * @summary Test vectorization of loops over MemorySegment, with native memory where the address is not always aligned.
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestMemorySegmentUnalignedAddress ByteBufferDirect

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestSplitPacks.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestSplitPacks.java
@@ -35,6 +35,7 @@ import java.nio.ByteOrder;
 /*
  * @test
  * @bug 8326139 8348659
+ * @key randomness
  * @summary Test splitting packs in SuperWord
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestSplitPacks nCOH_nAV_ySAC

--- a/test/hotspot/jtreg/compiler/vectorapi/Test8278948.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/Test8278948.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import jdk.test.lib.Utils;
 /*
  * @test
  * @bug 8278948
+ * @key randomness
  * @summary Intermediate integer promotion vector length encoding is calculated incorrectly on x86
  * @modules jdk.incubator.vector
  * @library /test/lib

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorAddMulReduction.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorAddMulReduction.java
@@ -38,6 +38,7 @@ import jdk.test.lib.Utils;
 /**
  * @test
  * @bug 8320725
+ * @key randomness
  * @library /test/lib /
  * @summary Verify non-strictly ordered AddReductionVF/VD and MulReductionVF/VD
  *          nodes are generated in VectorAPI

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorCompressExpandBits.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorCompressExpandBits.java
@@ -38,6 +38,7 @@ import jdk.test.lib.Utils;
 /**
  * @test
  * @bug 8301012
+ * @key randomness
  * @library /test/lib /
  * @requires os.arch == "aarch64" & vm.cpu.features ~= ".*sve2.*" & vm.cpu.features ~= ".*svebitperm.*"
  * @summary [vectorapi]: Intrinsify CompressBitsV/ExpandBitsV and add the AArch64 SVE backend implementation

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorMaskCastIdentityTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorMaskCastIdentityTest.java
@@ -24,6 +24,7 @@
 /*
 * @test
 * @bug 8356760
+* @key randomness
 * @library /test/lib /
 * @summary Optimize VectorMask.fromLong for all-true/all-false cases
 * @modules jdk.incubator.vector

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorMultiplyOpt.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorMultiplyOpt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.lang.reflect.Array;
 /**
  * @test
  * @bug 8341137
+ * @key randomness
  * @summary Optimize long vector multiplication using x86 VPMUL[U]DQ instruction.
  * @modules jdk.incubator.vector
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorSaturatedOperationsTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorSaturatedOperationsTest.java
@@ -24,6 +24,7 @@
 /**
 * @test
 * @bug 8338021 8342677 8349522
+* @key randomness
 * @summary Add IR validation tests for newly added saturated vector add / sub operations
 * @modules jdk.incubator.vector
 * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/vectorization/TestAutoVecIntMinMax.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestAutoVecIntMinMax.java
@@ -30,6 +30,7 @@ import jdk.test.lib.Utils;
 /*
  * @test
  * @bug 8288107
+ * @key randomness
  * @summary Auto-vectorization enhancement for integer Math.max/Math.min operations
  * @library /test/lib /
  * @requires vm.compiler2.enabled

--- a/test/hotspot/jtreg/compiler/vectorization/TestEor3AArch64.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestEor3AArch64.java
@@ -33,6 +33,7 @@ import jdk.test.lib.Utils;
 /*
  * @test
  * @bug 8293488
+ * @key randomness
  * @summary Test EOR3 Neon/SVE2 instruction for aarch64 SHA3 extension
  * @library /test/lib /
  * @requires os.arch == "aarch64"

--- a/test/hotspot/jtreg/compiler/vectorization/TestMacroLogicVector.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestMacroLogicVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 8241040
+ * @key randomness
  * @library /test/lib
  *
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions

--- a/test/hotspot/jtreg/compiler/vectorization/TestVectorZeroCount.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestVectorZeroCount.java
@@ -21,19 +21,19 @@
  * questions.
  */
 
+package compiler.vectorization;
+
+import java.util.Random;
+import jdk.test.lib.Utils;
+
 /* @test
  * @bug 8349637
+ * @key randomness
  * @requires vm.flavor == "server" & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
  * @summary Ensure that vectorization of numberOfLeadingZeros and numberOfTrailingZeros outputs correct values
  * @library /test/lib /
  * @run main/othervm/timeout=480 compiler.vectorization.TestVectorZeroCount
  */
-
-package compiler.vectorization;
-
-import java.util.Random;
-
-import jdk.test.lib.Utils;
 
 public class TestVectorZeroCount {
     private static final int SIZE = 1024;


### PR DESCRIPTION
clean backport. Tested changes locally

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8370489](https://bugs.openjdk.org/browse/JDK-8370489) needs maintainer approval

### Issue
 * [JDK-8370489](https://bugs.openjdk.org/browse/JDK-8370489): Some compiler tests miss the @<!---->key randomness (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/16.diff">https://git.openjdk.org/jdk26u/pull/16.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/16#issuecomment-3758238192)
</details>
