### PR TITLE
8375530: PPC64: incorrect quick verify_method_data_pointer check causes poor performance in debug build

### DIFF
--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -1109,11 +1109,11 @@ void InterpreterMacroAssembler::verify_method_data_pointer() {
   lhz(R11_scratch1, in_bytes(DataLayout::bci_offset()), R28_mdx);
   ld(R12_scratch2, in_bytes(Method::const_offset()), R19_method);
   addi(R11_scratch1, R11_scratch1, in_bytes(ConstMethod::codes_offset()));
-  add(R11_scratch1, R12_scratch2, R12_scratch2);
+  add(R11_scratch1, R11_scratch1, R12_scratch2);
   cmpd(CR0, R11_scratch1, R14_bcp);
   beq(CR0, verify_continue);
 
-  call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::verify_mdp ), R19_method, R14_bcp, R28_mdx);
+  call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::verify_mdp), R19_method, R14_bcp, R28_mdx);
 
   bind(verify_continue);
 #endif


### PR DESCRIPTION
This pull request contains a backport of commit [30f39d88](https://github.com/openjdk/jdk/commit/30f39d88e5af36bb6db458c03215e9fa6a31d6f3) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by David Briemann on 19 Jan 2026 and was reviewed by Martin Doerr and Aleksey Shipilev.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8375530](https://bugs.openjdk.org/browse/JDK-8375530) needs maintainer approval

### Issue
 * [JDK-8375530](https://bugs.openjdk.org/browse/JDK-8375530): PPC64: incorrect quick verify_method_data_pointer check causes poor performance in debug build (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/17/head:pull/17` \
`$ git checkout pull/17`

Update a local copy of the PR: \
`$ git checkout pull/17` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/17/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17`

View PR using the GUI difftool: \
`$ git pr show -t 17`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/17.diff">https://git.openjdk.org/jdk26u/pull/17.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/17#issuecomment-3767763186)
</details>
