### PR TITLE
8375657: RISC-V: Need to check size in SharedRuntime::is_wide_vector

### DIFF
--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -213,7 +213,7 @@ void RegisterSaver::restore_live_registers(MacroAssembler* masm) {
 // Is vector's size (in bytes) bigger than a size saved by default?
 // riscv does not ovlerlay the floating-point registers on vector registers like aarch64.
 bool SharedRuntime::is_wide_vector(int size) {
-  return UseRVV;
+  return UseRVV && size > 0;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [ca3e6236](https://github.com/openjdk/jdk/commit/ca3e6236a28794156cc2acf697755229c47735a8) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Dingli Zhang on 20 Jan 2026 and was reviewed by Feilong Jiang and Fei Yang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8375657](https://bugs.openjdk.org/browse/JDK-8375657) needs maintainer approval

### Issue
 * [JDK-8375657](https://bugs.openjdk.org/browse/JDK-8375657): RISC-V: Need to check size in SharedRuntime::is_wide_vector (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/20/head:pull/20` \
`$ git checkout pull/20`

Update a local copy of the PR: \
`$ git checkout pull/20` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/20/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20`

View PR using the GUI difftool: \
`$ git pr show -t 20`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/20.diff">https://git.openjdk.org/jdk26u/pull/20.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/20#issuecomment-3775791848)
</details>
