### PR TITLE
8375311: Some builds are missing debug helpers

### DIFF
--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -70,8 +70,10 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-// These functions needs to be exported on Windows only
-#define DEBUGEXPORT WINDOWS_ONLY(JNIEXPORT)
+// These functions needs to be exported on Windows
+// On Linux it is also beneficial to export them to avoid
+// losing them e.g. with linktime gc
+#define DEBUGEXPORT JNIEXPORT
 
 // Support for showing register content on asserts/guarantees.
 #ifdef CAN_SHOW_REGISTERS_ON_ASSERT
@@ -653,13 +655,12 @@ extern "C" DEBUGEXPORT intptr_t u5p(intptr_t addr,
 void pp(intptr_t p)          { pp((void*)p); }
 void pp(oop p)               { pp((void*)p); }
 
-void help() {
+extern "C" DEBUGEXPORT void help() {
   Command c("help");
   tty->print_cr("basic");
   tty->print_cr("  pp(void* p)         - try to make sense of p");
   tty->print_cr("  ps()                - print current thread stack");
   tty->print_cr("  pss()               - print all thread stacks");
-  tty->print_cr("  pm(int pc)          - print Method* given compiled PC");
   tty->print_cr("  findnm(intptr_t pc) - find nmethod*");
   tty->print_cr("  findm(intptr_t pc)  - find Method*");
   tty->print_cr("  find(intptr_t x)    - find & print nmethod/stub/bytecode/oop based on pointer into it");


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8375311](https://bugs.openjdk.org/browse/JDK-8375311) needs maintainer approval

### Issue
 * [JDK-8375311](https://bugs.openjdk.org/browse/JDK-8375311): Some builds are missing debug helpers (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/25.diff">https://git.openjdk.org/jdk26u/pull/25.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/25#issuecomment-3790178133)
</details>
