### PR TITLE
8286258: [Accessibility,macOS,VoiceOver] VoiceOver reads the spinner value wrong and sometime partially

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/NavigableTextAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/NavigableTextAccessibility.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -29,5 +29,6 @@
 @interface NavigableTextAccessibility : CommonComponentAccessibility <NSAccessibilityNavigableStaticText>
 
 @property(readonly) BOOL accessibleIsPasswordText;
+@property BOOL announceEditUpdates;
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/NavigableTextAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/NavigableTextAccessibility.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -60,6 +60,22 @@ static jmethodID sjm_getAccessibleEditableText = NULL;
     return [fJavaRole isEqualToString:@"passwordtext"];
 }
 
+- (id)init {
+    self = [super init];
+    if (self) {
+        _announceEditUpdates = YES;
+    }
+    return self;
+}
+
+- (void)suppressEditUpdates {
+    _announceEditUpdates = NO;
+}
+
+- (void)resumeEditUpdates {
+    _announceEditUpdates = YES;
+}
+
 // NSAccessibilityElement protocol methods
 
 - (NSRect)accessibilityFrameForRange:(NSRange)range
@@ -117,6 +133,9 @@ static jmethodID sjm_getAccessibleEditableText = NULL;
 
 - (NSString *)accessibilityStringForRange:(NSRange)range
 {
+    if (!_announceEditUpdates) {
+        return @"";
+    }
     JNIEnv *env = [ThreadUtilities getJNIEnv];
     GET_CACCESSIBLETEXT_CLASS_RETURN(nil);
     DECLARE_STATIC_METHOD_RETURN(jm_getStringForRange, sjc_CAccessibleText, "getStringForRange",
@@ -304,6 +323,12 @@ static jmethodID sjm_getAccessibleEditableText = NULL;
 - (id)accessibilityParent
 {
     return [super accessibilityParent];
+}
+
+- (void)postSelectedTextChanged
+{
+    [super postSelectedTextChanged];
+    [self resumeEditUpdates];
 }
 
 /*

--- a/test/jdk/javax/accessibility/JSpinner/CustomSpinnerAccessibilityTest.java
+++ b/test/jdk/javax/accessibility/JSpinner/CustomSpinnerAccessibilityTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.GridLayout;
+import java.lang.reflect.InvocationTargetException;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.SpinnerListModel;
+
+/*
+ * @test
+ * @bug 8286258
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @requires (os.family == "mac")
+ * @summary Checks that JSpinner with custom model announces
+ *          the value every time it is changed
+ * @run main/manual CustomSpinnerAccessibilityTest
+ */
+
+public class CustomSpinnerAccessibilityTest extends JPanel {
+    private static final String INSTRUCTIONS = """
+            1. Turn on VoiceOver
+            2. In the window named "Test UI" click on the text editor inside the
+               spinner component
+            3. Using up and down arrows change current month
+            4. Wait for the VoiceOver to finish speaking
+            5. Repeat steps 3 and 4 couple more times
+
+            If every time value of the spinner is changed VoiceOver
+            announces the new value click "Pass".
+            If instead the value is narrated only partially
+            and the new value is never fully narrated press "Fail".
+            """;
+
+    public CustomSpinnerAccessibilityTest() {
+        super(new GridLayout(0, 2));
+        String[] monthStrings = new java.text.DateFormatSymbols().getMonths();
+        int lastIndex = monthStrings.length - 1;
+        if (monthStrings[lastIndex] == null
+                || monthStrings[lastIndex].length() <= 0) {
+            String[] tmp = new String[lastIndex];
+            System.arraycopy(monthStrings, 0,
+                    tmp, 0, lastIndex);
+            monthStrings = tmp;
+        }
+
+        SpinnerListModel model = new SpinnerListModel(monthStrings);
+        JLabel label = new JLabel("Month: ");
+        add(label);
+        JSpinner spinner = new JSpinner(model);
+        label.setLabelFor(spinner);
+        add(spinner);
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("Custom Spinner Accessibility Test")
+                .instructions(INSTRUCTIONS)
+                .testUI(CustomSpinnerAccessibilityTest::new)
+                .build()
+                .awaitAndCheck();
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [8c82b58d](https://github.com/openjdk/jdk/commit/8c82b58db960a178566514731e1f8dcbc59b0161) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Alexander Zuev on 22 Jan 2026 and was reviewed by Prasanta Sadhukhan and Artem Semenov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8286258](https://bugs.openjdk.org/browse/JDK-8286258) needs maintainer approval

### Issue
 * [JDK-8286258](https://bugs.openjdk.org/browse/JDK-8286258): [Accessibility,macOS,VoiceOver] VoiceOver reads the spinner value wrong and sometime partially (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/26.diff">https://git.openjdk.org/jdk26u/pull/26.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/26#issuecomment-3792486508)
</details>
