### PR TITLE
8374178: Missing include in systemDictionary.cpp after JDK-8365526

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -54,6 +54,7 @@
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
 #include "oops/access.inline.hpp"
+#include "oops/constantPool.inline.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/klass.inline.hpp"
 #include "oops/method.inline.hpp"


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [9715e6da](https://github.com/openjdk/jdk/commit/9715e6da8355a103d9066bd15ce68b4773cbadcb) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jie Fu on 22 Dec 2025 and was reviewed by Kim Barrett and David Holmes.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8374178](https://bugs.openjdk.org/browse/JDK-8374178) needs maintainer approval

### Issue
 * [JDK-8374178](https://bugs.openjdk.org/browse/JDK-8374178): Missing include in systemDictionary.cpp after JDK-8365526 (**Bug** - P4 - Approved)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/28/head:pull/28` \
`$ git checkout pull/28`

Update a local copy of the PR: \
`$ git checkout pull/28` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/28/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28`

View PR using the GUI difftool: \
`$ git pr show -t 28`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/28.diff">https://git.openjdk.org/jdk26u/pull/28.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/28#issuecomment-3802648668)
</details>
