### PR TITLE
8373101: JdkClient and JdkServer test classes ignore namedGroups field

### DIFF
--- a/test/jdk/javax/net/ssl/TLSCommon/interop/JdkClient.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/interop/JdkClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.net.ssl.SNIHostName;
@@ -86,6 +87,16 @@ public class JdkClient extends AbstractClient {
         if (builder.getAppProtocols() != null) {
             sslParams.setApplicationProtocols(builder.getAppProtocols());
         }
+
+        NamedGroup[] namedGroups = builder.getNamedGroups();
+        if (namedGroups != null
+                && namedGroups.length > 0) {
+            String[] namedGroupStrs = Arrays.stream(namedGroups)
+                    .map(NamedGroup::name)
+                    .toArray(String[]::new);
+            sslParams.setNamedGroups(namedGroupStrs);
+        }
+
         socket.setSSLParameters(sslParams);
     }
 

--- a/test/jdk/javax/net/ssl/TLSCommon/interop/JdkServer.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/interop/JdkServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,9 +22,9 @@
  */
 
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.SocketException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.net.ssl.SNIHostName;
@@ -85,6 +85,16 @@ public class JdkServer extends AbstractServer {
                 System.out.println("appProtocol: " + appProtocol);
             }
         }
+
+        NamedGroup[] namedGroups = builder.getNamedGroups();
+        if (namedGroups != null
+                && namedGroups.length > 0) {
+            String[] namedGroupStrs = Arrays.stream(namedGroups)
+                    .map(NamedGroup::name)
+                    .toArray(String[]::new);
+            sslParams.setNamedGroups(namedGroupStrs);
+        }
+
         serverSocket.setSSLParameters(sslParams);
     }
 


### PR DESCRIPTION
TLSCommon tests passed after this change.
Straight Backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8373101](https://bugs.openjdk.org/browse/JDK-8373101) needs maintainer approval

### Issue
 * [JDK-8373101](https://bugs.openjdk.org/browse/JDK-8373101): JdkClient and JdkServer test classes ignore namedGroups field (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/30/head:pull/30` \
`$ git checkout pull/30`

Update a local copy of the PR: \
`$ git checkout pull/30` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/30/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30`

View PR using the GUI difftool: \
`$ git pr show -t 30`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/30.diff">https://git.openjdk.org/jdk26u/pull/30.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/30#issuecomment-3804065011)
</details>
