### PR TITLE
8373808: Refactor java/net/httpclient qpack and hpack tests to use JUnit

### DIFF
--- a/test/jdk/java/net/httpclient/http2/HpackBinaryTestDriver.java
+++ b/test/jdk/java/net/httpclient/http2/HpackBinaryTestDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,6 @@
  * @compile/module=java.net.http jdk/internal/net/http/hpack/SpecHelper.java
  * @compile/module=java.net.http jdk/internal/net/http/hpack/TestHelper.java
  * @compile/module=java.net.http jdk/internal/net/http/hpack/BuffersTestingKit.java
- * @run testng/othervm/timeout=240 java.net.http/jdk.internal.net.http.hpack.BinaryPrimitivesTest
+ * @run junit/othervm/timeout=240 java.net.http/jdk.internal.net.http.hpack.BinaryPrimitivesTest
  */
 public class HpackBinaryTestDriver { }

--- a/test/jdk/java/net/httpclient/http2/HpackCircularBufferDriver.java
+++ b/test/jdk/java/net/httpclient/http2/HpackCircularBufferDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,6 @@
  * @compile/module=java.net.http jdk/internal/net/http/hpack/SpecHelper.java
  * @compile/module=java.net.http jdk/internal/net/http/hpack/TestHelper.java
  * @compile/module=java.net.http jdk/internal/net/http/hpack/BuffersTestingKit.java
- * @run testng/othervm java.net.http/jdk.internal.net.http.hpack.CircularBufferTest
+ * @run junit/othervm java.net.http/jdk.internal.net.http.hpack.CircularBufferTest
  */
 public class HpackCircularBufferDriver { }

--- a/test/jdk/java/net/httpclient/http2/HpackDecoderDriver.java
+++ b/test/jdk/java/net/httpclient/http2/HpackDecoderDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,6 @@
  * @compile/module=java.net.http jdk/internal/net/http/hpack/SpecHelper.java
  * @compile/module=java.net.http jdk/internal/net/http/hpack/TestHelper.java
  * @compile/module=java.net.http jdk/internal/net/http/hpack/BuffersTestingKit.java
- * @run testng/othervm java.net.http/jdk.internal.net.http.hpack.DecoderTest
+ * @run junit/othervm java.net.http/jdk.internal.net.http.hpack.DecoderTest
  */
 public class HpackDecoderDriver { }

--- a/test/jdk/java/net/httpclient/http2/HpackEncoderDriver.java
+++ b/test/jdk/java/net/httpclient/http2/HpackEncoderDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,6 @@
  * @compile/module=java.net.http jdk/internal/net/http/hpack/SpecHelper.java
  * @compile/module=java.net.http jdk/internal/net/http/hpack/TestHelper.java
  * @compile/module=java.net.http jdk/internal/net/http/hpack/BuffersTestingKit.java
- * @run testng/othervm java.net.http/jdk.internal.net.http.hpack.EncoderTest
+ * @run junit/othervm java.net.http/jdk.internal.net.http.hpack.EncoderTest
  */
 public class HpackEncoderDriver { }

--- a/test/jdk/java/net/httpclient/http2/HpackHeaderTableDriver.java
+++ b/test/jdk/java/net/httpclient/http2/HpackHeaderTableDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,6 @@
  * @compile/module=java.net.http jdk/internal/net/http/hpack/SpecHelper.java
  * @compile/module=java.net.http jdk/internal/net/http/hpack/TestHelper.java
  * @compile/module=java.net.http jdk/internal/net/http/hpack/BuffersTestingKit.java
- * @run testng/othervm java.net.http/jdk.internal.net.http.hpack.HeaderTableTest
+ * @run junit/othervm java.net.http/jdk.internal.net.http.hpack.HeaderTableTest
  */
 public class HpackHeaderTableDriver { }

--- a/test/jdk/java/net/httpclient/http2/HpackHuffmanDriver.java
+++ b/test/jdk/java/net/httpclient/http2/HpackHuffmanDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,6 @@
  * @compile/module=java.net.http jdk/internal/net/http/hpack/SpecHelper.java
  * @compile/module=java.net.http jdk/internal/net/http/hpack/TestHelper.java
  * @compile/module=java.net.http jdk/internal/net/http/hpack/BuffersTestingKit.java
- * @run testng/othervm/timeout=300 java.net.http/jdk.internal.net.http.hpack.HuffmanTest
+ * @run junit/othervm/timeout=300 java.net.http/jdk.internal.net.http.hpack.HuffmanTest
  */
 public class HpackHuffmanDriver { }

--- a/test/jdk/java/net/httpclient/http2/HpackTestHelper.java
+++ b/test/jdk/java/net/httpclient/http2/HpackTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,6 @@
  * @compile/module=java.net.http jdk/internal/net/http/hpack/SpecHelper.java
  * @compile/module=java.net.http jdk/internal/net/http/hpack/TestHelper.java
  * @compile/module=java.net.http jdk/internal/net/http/hpack/BuffersTestingKit.java
- * @run testng/othervm java.net.http/jdk.internal.net.http.hpack.TestHelper
+ * @run junit/othervm java.net.http/jdk.internal.net.http.hpack.TestHelper
  */
 public class HpackTestHelperDriver { }

--- a/test/jdk/java/net/httpclient/http2/java.net.http/jdk/internal/net/http/hpack/BinaryPrimitivesTest.java
+++ b/test/jdk/java/net/httpclient/http2/java.net.http/jdk/internal/net/http/hpack/BinaryPrimitivesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,6 @@
  */
 package jdk.internal.net.http.hpack;
 
-import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -33,10 +32,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static jdk.internal.net.http.hpack.BuffersTestingKit.*;
 import static jdk.internal.net.http.hpack.TestHelper.newRandom;
+import org.junit.jupiter.api.Test;
 
 //
 // Some of the tests below overlap in what they test. This allows to diagnose
@@ -96,7 +96,7 @@ public final class BinaryPrimitivesTest {
                 totalCases++;
                 maxFilling = Math.max(maxFilling, buf.remaining());
                 r.reset().configure(N).read(buf);
-                assertEquals(r.get(), expected);
+                assertEquals(expected, r.get());
                 buf.clear();
             }
         }
@@ -127,7 +127,7 @@ public final class BinaryPrimitivesTest {
                                 throw new UncheckedIOException(e);
                             }
                         }
-                        assertEquals(r.get(), expected);
+                        assertEquals(expected, r.get());
                         r.reset();
                     });
             bb.clear();
@@ -167,7 +167,7 @@ public final class BinaryPrimitivesTest {
                             throw new UncheckedIOException(e);
                         }
                         // TODO: check payload here
-                        assertEquals(r.get(), expected);
+                        assertEquals(expected, r.get());
                         w.reset();
                         r.reset();
                         bb.clear();
@@ -209,7 +209,7 @@ public final class BinaryPrimitivesTest {
                 bytes.flip();
                 reader.read(bytes, chars);
                 chars.flip();
-                assertEquals(chars.toString(), expected);
+                assertEquals(expected, chars.toString());
                 reader.reset();
                 writer.reset();
             }
@@ -257,7 +257,7 @@ public final class BinaryPrimitivesTest {
                     throw new UncheckedIOException(e);
                 }
                 chars.flip();
-                assertEquals(chars.toString(), expected);
+                assertEquals(expected, chars.toString());
                 reader.reset();
                 writer.reset();
                 chars.clear();
@@ -301,7 +301,7 @@ public final class BinaryPrimitivesTest {
                     buf.position(p0);
                 }
                 chars.flip();
-                assertEquals(chars.toString(), expected);
+                assertEquals(expected, chars.toString());
                 reader.reset();
                 chars.clear();
             });
@@ -356,7 +356,7 @@ public final class BinaryPrimitivesTest {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-        assertEquals(reader.get(), expected);
+        assertEquals(expected, reader.get());
     }
 
     private void verifyWrite(byte[] expected, int data, int N) {
@@ -364,6 +364,6 @@ public final class BinaryPrimitivesTest {
         ByteBuffer buf = ByteBuffer.allocate(2 * expected.length);
         w.configure(data, N, 1).write(buf);
         buf.flip();
-        assertEquals(buf, ByteBuffer.wrap(expected));
+        assertEquals(ByteBuffer.wrap(expected), buf);
     }
 }

--- a/test/jdk/java/net/httpclient/http2/java.net.http/jdk/internal/net/http/hpack/CircularBufferTest.java
+++ b/test/jdk/java/net/httpclient/http2/java.net.http/jdk/internal/net/http/hpack/CircularBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,6 @@
  */
 package jdk.internal.net.http.hpack;
 
-import org.testng.annotations.Test;
 import jdk.internal.net.http.hpack.SimpleHeaderTable.CircularBuffer;
 
 import java.util.Arrays;
@@ -31,10 +30,11 @@ import java.util.Random;
 import java.util.concurrent.ArrayBlockingQueue;
 
 import static jdk.internal.net.http.common.Utils.pow2Size;
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static jdk.internal.net.http.hpack.TestHelper.assertVoidThrows;
 import static jdk.internal.net.http.hpack.TestHelper.newRandom;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 public final class CircularBufferTest {
 
@@ -143,7 +143,7 @@ public final class CircularBufferTest {
             for (int i = 0; i < gets; i++) {
                 Integer expected = referenceQueue.poll();
                 Integer actual = buffer.remove();
-                assertEquals(actual, expected);
+                assertEquals(expected, actual);
             }
         }
     }

--- a/test/jdk/java/net/httpclient/http2/java.net.http/jdk/internal/net/http/hpack/DecoderTest.java
+++ b/test/jdk/java/net/httpclient/http2/java.net.http/jdk/internal/net/http/hpack/DecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,6 @@
  */
 package jdk.internal.net.http.hpack;
 
-import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -33,9 +32,9 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static jdk.internal.net.http.hpack.TestHelper.*;
+import org.junit.jupiter.api.Test;
 
 //
 // Tests whose names start with "testX" are the ones captured from real HPACK
@@ -402,9 +401,9 @@ public final class DecoderTest {
     @Test
     public void sizeUpdate() throws IOException {
         Decoder d = new Decoder(4096);
-        assertEquals(d.getTable().maxSize(), 4096);
+        assertEquals(4096, d.getTable().maxSize());
         d.decode(ByteBuffer.wrap(new byte[]{0b00111110}), true, nopCallback()); // newSize = 30
-        assertEquals(d.getTable().maxSize(), 30);
+        assertEquals(30, d.getTable().maxSize());
     }
 
     @Test
@@ -650,8 +649,8 @@ public final class DecoderTest {
                     throw new UncheckedIOException(e);
                 }
             } while (i.hasNext());
-            assertEquals(d.getTable().getStateString(), expectedHeaderTable);
-            assertEquals(actual.stream().collect(Collectors.joining("\n")), expectedHeaderList);
+            assertEquals(expectedHeaderTable, d.getTable().getStateString());
+            assertEquals(expectedHeaderList, actual.stream().collect(Collectors.joining("\n")));
         });
 
         // Now introduce last ByteBuffer which is empty and EOF (mimics idiom
@@ -690,8 +689,8 @@ public final class DecoderTest {
                 throw new UncheckedIOException(e);
             }
 
-            assertEquals(d.getTable().getStateString(), expectedHeaderTable);
-            assertEquals(actual.stream().collect(Collectors.joining("\n")), expectedHeaderList);
+            assertEquals(expectedHeaderTable, d.getTable().getStateString());
+            assertEquals(expectedHeaderList, actual.stream().collect(Collectors.joining("\n")));
         });
     }
 
@@ -717,8 +716,8 @@ public final class DecoderTest {
             throw new UncheckedIOException(e);
         }
 
-        assertEquals(d.getTable().getStateString(), expectedHeaderTable);
-        assertEquals(actual.stream().collect(Collectors.joining("\n")), expectedHeaderList);
+        assertEquals(expectedHeaderTable, d.getTable().getStateString());
+        assertEquals(expectedHeaderList, actual.stream().collect(Collectors.joining("\n")));
     }
 
     private static DecodingCallback nopCallback() {

--- a/test/jdk/java/net/httpclient/http2/java.net.http/jdk/internal/net/http/hpack/EncoderTest.java
+++ b/test/jdk/java/net/httpclient/http2/java.net.http/jdk/internal/net/http/hpack/EncoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,6 @@
  */
 package jdk.internal.net.http.hpack;
 
-import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.nio.Buffer;
@@ -40,8 +39,9 @@ import static jdk.internal.net.http.hpack.BuffersTestingKit.forEachSplit;
 import static jdk.internal.net.http.hpack.SpecHelper.toHexdump;
 import static jdk.internal.net.http.hpack.TestHelper.assertVoidThrows;
 import static java.util.Arrays.asList;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 // TODO: map textual representation of commands from the spec to actual
 // calls to encoder (actually, this is a good idea for decoder as well)
@@ -627,10 +627,10 @@ public final class EncoderTest {
                              String expectedTableState) {
 
         String actualTableState = encoder.getHeaderTable().getStateString();
-        assertEquals(actualTableState, expectedTableState);
+        assertEquals(expectedTableState, actualTableState);
 
         String actualHexdump = toHexdump(output);
-        assertEquals(actualHexdump, expectedHexdump.replaceAll("\\n", " "));
+        assertEquals(expectedHexdump.replaceAll("\\n", " "), actualHexdump);
     }
 
     // initial size - the size encoder is constructed with
@@ -657,7 +657,7 @@ public final class EncoderTest {
                 actual.add(capacity);
             }
         });
-        assertEquals(actual, expected);
+        assertEquals(expected, actual);
     }
 
     //

--- a/test/jdk/java/net/httpclient/http2/java.net.http/jdk/internal/net/http/hpack/HeaderTableTest.java
+++ b/test/jdk/java/net/httpclient/http2/java.net.http/jdk/internal/net/http/hpack/HeaderTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,15 +23,15 @@
 package jdk.internal.net.http.hpack;
 
 import jdk.internal.net.http.hpack.SimpleHeaderTable.HeaderField;
-import org.testng.annotations.Test;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 public class HeaderTableTest extends SimpleHeaderTableTest {
 
@@ -61,8 +61,8 @@ public class HeaderTableTest extends SimpleHeaderTableTest {
         staticHeaderFields.forEach((key, expectedHeaderField) -> {
             // lookup
             HeaderField actualHeaderField = table.get(key);
-            assertEquals(actualHeaderField.name, expectedHeaderField.name);
-            assertEquals(actualHeaderField.value, expectedHeaderField.value);
+            assertEquals(expectedHeaderField.name, actualHeaderField.name);
+            assertEquals(expectedHeaderField.value, actualHeaderField.value);
 
             // reverse lookup (name, value)
             String hName = expectedHeaderField.name;
@@ -70,13 +70,13 @@ public class HeaderTableTest extends SimpleHeaderTableTest {
             int expectedIndex = key;
             int actualIndex = table.indexOf(hName, hValue);
 
-            assertEquals(actualIndex, expectedIndex);
+            assertEquals(expectedIndex, actualIndex);
 
             // reverse lookup (name)
             Set<Integer> expectedIndexes = indexes.get(hName);
             int actualMinimalIndex = table.indexOf(hName, "blah-blah");
 
-            assertTrue(expectedIndexes.contains(-actualMinimalIndex));
+            Assertions.assertTrue(expectedIndexes.contains(-actualMinimalIndex));
         });
     }
 
@@ -88,9 +88,9 @@ public class HeaderTableTest extends SimpleHeaderTableTest {
         table.put("bender", "rodriguez");
         table.put("bender", "rodriguez");
 
-        assertEquals(table.length(), oldLength + 3); // more like an assumption
+        assertEquals(oldLength + 3, table.length()); // more like an assumption
         int i = table.indexOf("bender", "rodriguez");
-        assertEquals(i, oldLength + 1);
+        assertEquals(oldLength + 1, i);
     }
 
     @Test
@@ -98,13 +98,13 @@ public class HeaderTableTest extends SimpleHeaderTableTest {
         HeaderTable table = createHeaderTable(256);
         int oldLength = table.length();
         table.put("bender", "rodriguez");
-        assertEquals(table.indexOf("bender", "rodriguez"), oldLength + 1);
+        assertEquals(oldLength + 1, table.indexOf("bender", "rodriguez"));
         table.put("bender", "rodriguez");
-        assertEquals(table.indexOf("bender", "rodriguez"), oldLength + 1);
+        assertEquals(oldLength + 1, table.indexOf("bender", "rodriguez"));
         table.evictEntry();
-        assertEquals(table.indexOf("bender", "rodriguez"), oldLength + 1);
+        assertEquals(oldLength + 1, table.indexOf("bender", "rodriguez"));
         table.evictEntry();
-        assertEquals(table.indexOf("bender", "rodriguez"), 0);
+        assertEquals(0, table.indexOf("bender", "rodriguez"));
     }
 
     @Test
@@ -114,9 +114,9 @@ public class HeaderTableTest extends SimpleHeaderTableTest {
         int idx = rnd.nextInt(oldLength) + 1;
         HeaderField f = table.get(idx);
         table.put(f.name, f.value);
-        assertEquals(table.length(), oldLength + 1);
+        assertEquals(oldLength + 1, table.length());
         int i = table.indexOf(f.name, f.value);
-        assertEquals(i, idx);
+        assertEquals(idx, i);
     }
 
     @Test
@@ -137,16 +137,16 @@ public class HeaderTableTest extends SimpleHeaderTableTest {
             String s = String.valueOf(j);
             int actualIndex = table.indexOf(s, s);
             int expectedIndex = STATIC_TABLE_LENGTH + NUM_HEADERS - j + 1;
-            assertEquals(actualIndex, expectedIndex);
+            assertEquals(expectedIndex, actualIndex);
         }
         // as well as for just a name lookup
         for (int j = 1; j <= NUM_HEADERS; j++) {
             String s = String.valueOf(j);
             int actualIndex = table.indexOf(s, "blah");
             int expectedIndex = -(STATIC_TABLE_LENGTH + NUM_HEADERS - j + 1);
-            assertEquals(actualIndex, expectedIndex);
+            assertEquals(expectedIndex, actualIndex);
         }
         // lookup for non-existent name returns 0
-        assertEquals(table.indexOf("chupacabra", "1"), 0);
+        assertEquals(0, table.indexOf("chupacabra", "1"));
     }
 }

--- a/test/jdk/java/net/httpclient/http2/java.net.http/jdk/internal/net/http/hpack/HuffmanTest.java
+++ b/test/jdk/java/net/httpclient/http2/java.net.http/jdk/internal/net/http/hpack/HuffmanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@ package jdk.internal.net.http.hpack;
 
 import jdk.internal.net.http.hpack.Huffman.Reader;
 import jdk.internal.net.http.hpack.Huffman.Writer;
-import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -39,8 +38,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static jdk.internal.net.http.hpack.HPACK.bytesForBits;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 public final class HuffmanTest {
 
@@ -412,8 +412,8 @@ public final class HuffmanTest {
             // might not be printable/visible)
             int expected = code.sym;
             int actual = (int) output.charAt(0);
-            assertEquals(output.length(), 1); // exactly 1 character
-            assertEquals(actual, expected);
+            assertEquals(1, output.length()); // exactly 1 character
+            assertEquals(expected, actual);
         }
     }
 
@@ -653,7 +653,7 @@ public final class HuffmanTest {
                 w.from(str, 0, str.length()).write(buffer);
                 Reader r = READER.get();
                 r.read(buffer.flip(), b, true);
-                assertEquals(b.toString(), str);
+                assertEquals(str, b.toString());
             }
 
             private void roundTrip(int... lengths) throws IOException {
@@ -765,7 +765,7 @@ public final class HuffmanTest {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-        assertEquals(actual.toString(), decoded);
+        assertEquals(decoded, actual.toString());
     }
 
     private static void readExhaustively(String hexdump, String decoded) {
@@ -782,7 +782,7 @@ public final class HuffmanTest {
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
-            assertEquals(actual.toString(), decoded);
+            assertEquals(decoded, actual.toString());
             reader.reset();
             actual.setLength(0);
         });
@@ -796,7 +796,7 @@ public final class HuffmanTest {
         boolean written = writer.write(destination);
         assertTrue(written);
         String actual = SpecHelper.toHexdump(destination.flip());
-        assertEquals(actual, hexdump);
+        assertEquals(hexdump, actual);
         writer.reset();
     }
 
@@ -815,7 +815,7 @@ public final class HuffmanTest {
             assertTrue(written);
             ByteBuffer concated = BuffersTestingKit.concat(byteBuffers);
             String actual = SpecHelper.toHexdump(concated);
-            assertEquals(actual, hexdump);
+            assertEquals(hexdump, actual);
             writer.reset();
         });
     }

--- a/test/jdk/java/net/httpclient/http2/java.net.http/jdk/internal/net/http/hpack/SimpleHeaderTableTest.java
+++ b/test/jdk/java/net/httpclient/http2/java.net.http/jdk/internal/net/http/hpack/SimpleHeaderTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,6 @@
 package jdk.internal.net.http.hpack;
 
 import jdk.internal.net.http.hpack.SimpleHeaderTable.HeaderField;
-import org.testng.annotations.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -39,7 +38,8 @@ import static jdk.internal.net.http.hpack.TestHelper.assertThrows;
 import static jdk.internal.net.http.hpack.TestHelper.assertVoidThrows;
 import static jdk.internal.net.http.hpack.TestHelper.newRandom;
 import static java.lang.String.format;
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 public class SimpleHeaderTableTest {
 
@@ -125,8 +125,8 @@ public class SimpleHeaderTableTest {
         Map<Integer, HeaderField> staticHeaderFields = createStaticEntries();
         staticHeaderFields.forEach((index, expectedHeaderField) -> {
             SimpleHeaderTable.HeaderField actualHeaderField = table.get(index);
-            assertEquals(actualHeaderField.name, expectedHeaderField.name);
-            assertEquals(actualHeaderField.value, expectedHeaderField.value);
+            assertEquals(expectedHeaderField.name, actualHeaderField.name);
+            assertEquals(expectedHeaderField.value, actualHeaderField.value);
         });
     }
 
@@ -134,8 +134,8 @@ public class SimpleHeaderTableTest {
     public void constructorSetsMaxSize() {
         int size = rnd.nextInt(64);
         SimpleHeaderTable table = createHeaderTable(size);
-        assertEquals(table.size(), 0);
-        assertEquals(table.maxSize(), size);
+        assertEquals(0, table.size());
+        assertEquals(size, table.maxSize());
     }
 
     @Test
@@ -152,7 +152,7 @@ public class SimpleHeaderTableTest {
     public void zeroMaximumSize() {
         SimpleHeaderTable table = createHeaderTable(0);
         table.setMaxSize(0);
-        assertEquals(table.maxSize(), 0);
+        assertEquals(0, table.maxSize());
     }
 
     @Test
@@ -177,7 +177,7 @@ public class SimpleHeaderTableTest {
     @Test
     public void length() {
         SimpleHeaderTable table = createHeaderTable(0);
-        assertEquals(table.length(), STATIC_TABLE_LENGTH);
+        assertEquals(STATIC_TABLE_LENGTH, table.length());
     }
 
     @Test
@@ -203,14 +203,14 @@ public class SimpleHeaderTableTest {
 
         table.put(name, value);
         SimpleHeaderTable.HeaderField f = table.get(idx);
-        assertEquals(f.name, name);
-        assertEquals(f.value, value);
+        assertEquals(name, f.name);
+        assertEquals(value, f.value);
     }
 
     @Test
     public void staticTableHasZeroSize() {
         SimpleHeaderTable table = createHeaderTable(0);
-        assertEquals(table.size(), 0);
+        assertEquals(0, table.size());
     }
 
     // TODO: negative indexes check
@@ -236,13 +236,13 @@ public class SimpleHeaderTableTest {
             SimpleHeaderTable.HeaderField f = table.get(STATIC_TABLE_LENGTH + j);
             int actualName = Integer.parseInt(f.name);
             int expectedName = NUM_HEADERS - j + 1;
-            assertEquals(actualName, expectedName);
+            assertEquals(expectedName, actualName);
         }
         // Entries MUST be evicted in the order they were added:
         //   the newer the entry the later it is evicted
         for (int k = 1; k <= NUM_HEADERS; k++) {
             SimpleHeaderTable.HeaderField f = table.evictEntry();
-            assertEquals(f.name, String.valueOf(k));
+            assertEquals(String.valueOf(k), f.name);
         }
     }
 
@@ -257,7 +257,7 @@ public class SimpleHeaderTableTest {
         Locale.setDefault(Locale.FRENCH);
         try {
             String s = format("%.1f", 3.1);
-            assertEquals(s, "3,1"); // assumption of the test, otherwise the test is useless
+            assertEquals("3,1", s); // assumption of the test, otherwise the test is useless
             testToString0();
         } finally {
             Locale.setDefault(locale);
@@ -272,7 +272,7 @@ public class SimpleHeaderTableTest {
             String expected = format(
                     "dynamic length: %s, full length: %s, used space: %s/%s (%.1f%%)",
                     0, STATIC_TABLE_LENGTH, 0, maxSize, 0.0);
-            assertEquals(table.toString(), expected);
+            assertEquals(expected, table.toString());
         }
 
         {
@@ -290,7 +290,7 @@ public class SimpleHeaderTableTest {
             String expected = format(
                     "dynamic length: %s, full length: %s, used space: %s/%s (%.1f%%)",
                     1, STATIC_TABLE_LENGTH + 1, used, size, ratio);
-            assertEquals(s, expected);
+            assertEquals(expected, s);
         }
 
         {
@@ -301,7 +301,7 @@ public class SimpleHeaderTableTest {
             String expected =
                     format("dynamic length: %s, full length: %s, used space: %s/%s (%.1f%%)",
                            2, STATIC_TABLE_LENGTH + 2, 78, 78, 100.0);
-            assertEquals(s, expected);
+            assertEquals(expected, s);
         }
     }
 
@@ -310,9 +310,8 @@ public class SimpleHeaderTableTest {
         SimpleHeaderTable table = createHeaderTable(256);
         table.put("custom-key", "custom-header");
         // @formatter:off
-        assertEquals(table.getStateString(),
-                     "[  1] (s =  55) custom-key: custom-header\n" +
-                     "      Table size:  55");
+        assertEquals("[  1] (s =  55) custom-key: custom-header\n" +
+                     "      Table size:  55", table.getStateString());
         // @formatter:on
     }
 

--- a/test/jdk/java/net/httpclient/http2/java.net.http/jdk/internal/net/http/hpack/TestHelper.java
+++ b/test/jdk/java/net/httpclient/http2/java.net.http/jdk/internal/net/http/hpack/TestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,10 @@
  */
 package jdk.internal.net.http.hpack;
 
-import org.testng.annotations.Test;
 
 import java.util.Objects;
 import java.util.Random;
+import org.junit.jupiter.api.Test;
 
 public final class TestHelper {
 

--- a/test/jdk/java/net/httpclient/qpack/BlockingDecodingTest.java
+++ b/test/jdk/java/net/httpclient/qpack/BlockingDecodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,6 @@ import jdk.internal.net.http.http3.frames.SettingsFrame;
 import jdk.internal.net.http.qpack.DecodingCallback;
 import jdk.internal.net.http.qpack.DynamicTable;
 import jdk.internal.net.http.qpack.Encoder;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -43,7 +41,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.testng.Assert.assertNotEquals;
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import org.junit.jupiter.api.Test;
 
 /*
  * @test
@@ -59,7 +59,7 @@ import static org.testng.Assert.assertNotEquals;
  *          java.net.http/jdk.internal.net.http.http3.frames
  *          java.net.http/jdk.internal.net.http.http3
  * @build EncoderDecoderConnector
- * @run testng/othervm -Djdk.internal.httpclient.qpack.log.level=EXTRA BlockingDecodingTest
+ * @run junit/othervm -Djdk.internal.httpclient.qpack.log.level=EXTRA BlockingDecodingTest
  */
 
 
@@ -94,7 +94,7 @@ public class BlockingDecodingTest {
         encoder.header(context, header.name(), header.value(),
                 false, IGNORE_RECEIVED_COUNT_CHECK);
         headerFrameWriter.write(headersBb);
-        assertNotEquals(headersBb.position(), 0);
+        assertNotEquals(0, headersBb.position());
         headersBb.flip();
         buffers.add(headersBb);
 
@@ -110,8 +110,8 @@ public class BlockingDecodingTest {
         // and the default number of blocked streams (0) will be exceeded (1).
         var lastHttp3Error = decodingCallback.lastHttp3Error.get();
         System.err.println("Last Http3Error: " + lastHttp3Error);
-        Assert.assertEquals(lastHttp3Error, Http3Error.QPACK_DECOMPRESSION_FAILED);
-        Assert.assertFalse(decodingCallback.completed.isDone());
+        Assertions.assertEquals(Http3Error.QPACK_DECOMPRESSION_FAILED, lastHttp3Error);
+        Assertions.assertFalse(decodingCallback.completed.isDone());
     }
 
     @Test
@@ -149,7 +149,7 @@ public class BlockingDecodingTest {
         encoder.header(context, expectedHeader.name,
                 expectedHeader.value, false, IGNORE_RECEIVED_COUNT_CHECK);
         headerFrameWriter.write(headersBb);
-        assertNotEquals(headersBb.position(), 0);
+        assertNotEquals(0, headersBb.position());
         headersBb.flip();
         buffers.add(headersBb);
 
@@ -165,12 +165,12 @@ public class BlockingDecodingTest {
         // and the default number of blocked streams (0) will be exceeded (1).
         var lastHttp3Error = decodingCallback.lastHttp3Error.get();
         System.err.println("Last Http3Error: " + lastHttp3Error);
-        Assert.assertNull(lastHttp3Error);
-        Assert.assertNull(decodingCallback.lastThrowable.get());
-        Assert.assertTrue(decodingCallback.completed.isDone());
+        Assertions.assertNull(lastHttp3Error);
+        Assertions.assertNull(decodingCallback.lastThrowable.get());
+        Assertions.assertTrue(decodingCallback.completed.isDone());
         // Check that onDecoded was called for the test entry
         var decodedHeader = decodingCallback.decodedHeaders.get(0);
-        Assert.assertEquals(decodedHeader, expectedHeader);
+        Assertions.assertEquals(expectedHeader, decodedHeader);
     }
 
     @Test
@@ -224,7 +224,7 @@ public class BlockingDecodingTest {
                                 IGNORE_RECEIVED_COUNT_CHECK);
                         headerFrameWriter.write(headersBb);
                     }
-                    assertNotEquals(headersBb.position(), 0);
+                    assertNotEquals(0, headersBb.position());
                     headersBb.flip();
                     buffers.add(headersBb);
 
@@ -261,13 +261,13 @@ public class BlockingDecodingTest {
         // Check results of each decoding task
         for (var decodingResultFuture : decodingTaskResults) {
             var taskCallback = decodingResultFuture.get();
-            Assert.assertNull(taskCallback.lastHttp3Error.get());
-            Assert.assertNull(taskCallback.lastThrowable.get());
+            Assertions.assertNull(taskCallback.lastHttp3Error.get());
+            Assertions.assertNull(taskCallback.lastThrowable.get());
             long decodingTaskCompleted = taskCallback.completedTimestamp.get();
             System.err.println("Decoding task completion timestamp: " + decodingTaskCompleted);
-            Assert.assertTrue(decodingTaskCompleted >= updateDoneTimeStamp);
+            Assertions.assertTrue(decodingTaskCompleted >= updateDoneTimeStamp);
             var decodedHeaders = taskCallback.decodedHeaders;
-            Assert.assertEquals(decodedHeaders, expectedHeaders);
+            Assertions.assertEquals(expectedHeaders, decodedHeaders);
         }
     }
 

--- a/test/jdk/java/net/httpclient/qpack/DecoderSectionSizeLimitTest.java
+++ b/test/jdk/java/net/httpclient/qpack/DecoderSectionSizeLimitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@
  *          java.net.http/jdk.internal.net.http.http3.frames
  *          java.net.http/jdk.internal.net.http.http3
  * @build EncoderDecoderConnector
- * @run testng/othervm -Djdk.internal.httpclient.qpack.log.level=NORMAL
+ * @run junit/othervm -Djdk.internal.httpclient.qpack.log.level=NORMAL
  *                    DecoderSectionSizeLimitTest
  */
 
@@ -48,18 +48,21 @@ import jdk.internal.net.http.qpack.DecodingCallback;
 import jdk.internal.net.http.qpack.DynamicTable;
 import jdk.internal.net.http.qpack.Encoder;
 import jdk.test.lib.RandomFactory;
-import org.testng.Assert;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class DecoderSectionSizeLimitTest {
-    @Test(dataProvider = "headerSequences")
+    @ParameterizedTest
+    @MethodSource("headerSequences")
     public void fieldSectionSizeLimitExceeded(List<TestHeader> headersSequence,
                                               long maxFieldSectionSize) {
 
@@ -144,21 +147,20 @@ public class DecoderSectionSizeLimitTest {
                 System.err.printf("Decoding error observed during buffer #%d processing: %s throwable: %s%n",
                         bufferIdx, decodingError, decodingCallback.lastThrowable.get());
                 if (decoderErrorExpected) {
-                    Assert.assertEquals(decodingError, Http3Error.QPACK_DECOMPRESSION_FAILED);
+                    Assertions.assertEquals(Http3Error.QPACK_DECOMPRESSION_FAILED, decodingError);
                     return;
                 } else {
-                    Assert.fail("No HTTP/3 error was expected");
+                    Assertions.fail("No HTTP/3 error was expected");
                 }
             } else {
                 System.err.println("Buffer #" + bufferIdx + " readout completed without errors");
             }
         }
         if (decoderErrorExpected) {
-            Assert.fail("HTTP/3 error was expected but was not observed");
+            Assertions.fail("HTTP/3 error was expected but was not observed");
         }
     }
 
-    @DataProvider
     public Object[][] headerSequences() {
         List<Object[]> testCases = new ArrayList<>();
         for (var sequence : generateHeaderSequences()) {

--- a/test/jdk/java/net/httpclient/qpack/DynamicTableFieldLineRepresentationTest.java
+++ b/test/jdk/java/net/httpclient/qpack/DynamicTableFieldLineRepresentationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ import jdk.internal.net.http.qpack.DecodingCallback;
 import jdk.internal.net.http.qpack.DynamicTable;
 import jdk.internal.net.http.qpack.Encoder;
 import jdk.test.lib.RandomFactory;
-import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -37,7 +36,8 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.testng.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 /*
  * @test
@@ -55,7 +55,7 @@ import static org.testng.Assert.*;
  *          java.net.http/jdk.internal.net.http.http3.frames
  *          java.net.http/jdk.internal.net.http.http3
  * @build EncoderDecoderConnector
- * @run testng/othervm -Djdk.internal.httpclient.qpack.log.level=EXTRA
+ * @run junit/othervm -Djdk.internal.httpclient.qpack.log.level=EXTRA
  *                     -Djdk.http.qpack.allowBlockingEncoding=true
  *                     -Djdk.http.qpack.decoderBlockedStreams=4
  *                     DynamicTableFieldLineRepresentationTest
@@ -105,7 +105,7 @@ public class DynamicTableFieldLineRepresentationTest {
 
         // Write the header
         headerFrameWriter.write(headersBb);
-        assertNotEquals(headersBb.position(), 0);
+        assertNotEquals(0, headersBb.position());
         headersBb.flip();
         buffers.add(headersBb);
 
@@ -115,7 +115,7 @@ public class DynamicTableFieldLineRepresentationTest {
         // Decode headers
         decoder.decodeHeader(buffers.get(0), false, headerFrameReader);
         decoder.decodeHeader(buffers.get(1), true, headerFrameReader);
-        assertEquals(callback.lastIndexedName,name);
+        assertEquals(name, callback.lastIndexedName);
     }
 
     //4.5.3.  Indexed Field Line with Post-Base Index
@@ -160,7 +160,7 @@ public class DynamicTableFieldLineRepresentationTest {
 
         // Write the header
         headerFrameWriter.write(headersBb);
-        assertNotEquals(headersBb.position(), 0);
+        assertNotEquals(0, headersBb.position());
         headersBb.flip();
         buffers.add(headersBb);
 
@@ -170,8 +170,8 @@ public class DynamicTableFieldLineRepresentationTest {
         // Decode headers
         decoder.decodeHeader(buffers.get(0), false, headerFrameReader);
         decoder.decodeHeader(buffers.get(1), true, headerFrameReader);
-        assertEquals(callback.lastIndexedName,name);
-        assertEquals(callback.lastValue,value);
+        assertEquals(name, callback.lastIndexedName);
+        assertEquals(value, callback.lastValue);
     }
 
     // 4.5.4.  Literal Field Line with Name Reference
@@ -221,7 +221,7 @@ public class DynamicTableFieldLineRepresentationTest {
 
         // Write the header
         headerFrameWriter.write(headersBb);
-        assertNotEquals(headersBb.position(), 0);
+        assertNotEquals(0, headersBb.position());
         headersBb.flip();
         buffers.add(headersBb);
 
@@ -231,7 +231,7 @@ public class DynamicTableFieldLineRepresentationTest {
         // Decode headers
         decoder.decodeHeader(buffers.get(0), false, headerFrameReader);
         decoder.decodeHeader(buffers.get(1), true, headerFrameReader);
-        assertEquals(callback.lastReferenceName, name);
+        assertEquals(name, callback.lastReferenceName);
     }
 
     //4.5.5.  Literal Field Line with Post-Base Name Reference
@@ -276,7 +276,7 @@ public class DynamicTableFieldLineRepresentationTest {
 
         // Write the header
         headerFrameWriter.write(headersBb);
-        assertNotEquals(headersBb.position(), 0);
+        assertNotEquals(0, headersBb.position());
         headersBb.flip();
         buffers.add(headersBb);
 
@@ -286,8 +286,8 @@ public class DynamicTableFieldLineRepresentationTest {
         // Decode headers
         decoder.decodeHeader(buffers.get(0), false, headerFrameReader);
         decoder.decodeHeader(buffers.get(1), true, headerFrameReader);
-        assertEquals(callback.lastReferenceName, name);
-        assertEquals(callback.lastValue, value);
+        assertEquals(name, callback.lastReferenceName);
+        assertEquals(value, callback.lastValue);
     }
 
     private void configureConnector(EncoderDecoderConnector.EncoderDecoderPair connector, int numberOfEntries){
@@ -362,8 +362,8 @@ public class DynamicTableFieldLineRepresentationTest {
         @Override
         public void onIndexed(long actualIndex, CharSequence actualName, CharSequence actualValue) {
             System.out.println("Indexed called");
-            assertEquals(actualName, name);
-            assertEquals(actualValue, value);
+            assertEquals(name, actualName);
+            assertEquals(value, actualValue);
             lastValue = value;
             lastIndexedName = name;
         }
@@ -375,8 +375,8 @@ public class DynamicTableFieldLineRepresentationTest {
                                                boolean valueHuffman,
                                                boolean hideIntermediary) {
             System.out.println("Literal with name reference called");
-            assertEquals(actualName.toString(), name);
-            assertEquals(actualValue.toString(), value);
+            assertEquals(name, actualName.toString());
+            assertEquals(value, actualValue.toString());
             lastReferenceName = name;
             lastValue = value;
         }
@@ -386,8 +386,8 @@ public class DynamicTableFieldLineRepresentationTest {
                                              CharSequence actualValue, boolean valueHuffman,
                                              boolean hideIntermediary) {
             System.out.println("Literal with literal name called");
-            assertEquals(actualName.toString(), name);
-            assertEquals(actualValue.toString(), value);
+            assertEquals(name, actualName.toString());
+            assertEquals(value, actualValue.toString());
             lastLiteralName = name;
             lastValue = value;
         }

--- a/test/jdk/java/net/httpclient/qpack/EncoderDecoderConnectionTest.java
+++ b/test/jdk/java/net/httpclient/qpack/EncoderDecoderConnectionTest.java
@@ -27,12 +27,12 @@ import jdk.internal.net.http.http3.frames.SettingsFrame;
 import jdk.internal.net.http.qpack.TableEntry;
 import jdk.internal.net.http.qpack.writers.EncoderInstructionsWriter;
 import jdk.internal.net.http.qpack.writers.HeaderFrameWriter;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /*
  * @test
@@ -48,7 +48,7 @@ import java.util.concurrent.atomic.AtomicReference;
  *          java.net.http/jdk.internal.net.http.http3.frames
  *          java.net.http/jdk.internal.net.http.http3
  * @build EncoderDecoderConnector
- * @run testng/othervm -Djdk.internal.httpclient.qpack.log.level=EXTRA
+ * @run junit/othervm -Djdk.internal.httpclient.qpack.log.level=EXTRA
  *                     EncoderDecoderConnectionTest
  */
 public class EncoderDecoderConnectionTest {
@@ -77,17 +77,17 @@ public class EncoderDecoderConnectionTest {
         encoder.setTableCapacity(capacityToSet);
 
         // Check that no errors observed
-        Assert.assertNull(encoderErrorHandler.error.get());
-        Assert.assertNull(encoderErrorHandler.http3Error.get());
-        Assert.assertNull(decoderErrorHandler.error.get());
-        Assert.assertNull(decoderErrorHandler.http3Error.get());
+        Assertions.assertNull(encoderErrorHandler.error.get());
+        Assertions.assertNull(encoderErrorHandler.http3Error.get());
+        Assertions.assertNull(decoderErrorHandler.error.get());
+        Assertions.assertNull(decoderErrorHandler.http3Error.get());
 
         // Check that encoder's table capacity is updated
-        Assert.assertEquals(conn.encoderTable().capacity(), capacityToSet);
+        Assertions.assertEquals(capacityToSet, conn.encoderTable().capacity());
         // Since encoder/decoder streams are cross-wired we expect see dynamic
         // table capacity updated for the decoder too
-        Assert.assertEquals(conn.decoderTable().capacity(),
-                conn.encoderTable().capacity());
+        Assertions.assertEquals(conn.encoderTable().capacity(),
+                                conn.decoderTable().capacity());
     }
 
     @Test
@@ -122,10 +122,10 @@ public class EncoderDecoderConnectionTest {
         var encoderInstructionWriter = new EncoderInstructionsWriter();
 
         // Check that no errors observed
-        Assert.assertNull(encoderErrorHandler.error.get());
-        Assert.assertNull(encoderErrorHandler.http3Error.get());
-        Assert.assertNull(decoderErrorHandler.error.get());
-        Assert.assertNull(decoderErrorHandler.http3Error.get());
+        Assertions.assertNull(encoderErrorHandler.error.get());
+        Assertions.assertNull(encoderErrorHandler.http3Error.get());
+        Assertions.assertNull(decoderErrorHandler.error.get());
+        Assertions.assertNull(decoderErrorHandler.http3Error.get());
 
         // Issue the insert instruction on encoder stream
         conn.encoderTable().insertWithEncoderStreamUpdate(entryToInsert,
@@ -133,8 +133,8 @@ public class EncoderDecoderConnectionTest {
                 encoder.newEncodingContext(0, 0, new HeaderFrameWriter()));
         var encoderHeader = conn.encoderTable().get(0);
         var decoderHeader = conn.decoderTable().get(0);
-        Assert.assertEquals(encoderHeader.name(), decoderHeader.name());
-        Assert.assertEquals(encoderHeader.value(), decoderHeader.value());
+        Assertions.assertEquals(decoderHeader.name(), encoderHeader.name());
+        Assertions.assertEquals(decoderHeader.value(), encoderHeader.value());
     }
 
     @Test
@@ -160,12 +160,12 @@ public class EncoderDecoderConnectionTest {
 
         // QPACK_ENCODER_STREAM_ERROR is expected on the decoder side
         // since the decoder dynamic table capacity was not updated
-        Assert.assertEquals(decoderErrorHandler.http3Error.get(),
-                Http3Error.QPACK_ENCODER_STREAM_ERROR);
+        Assertions.assertEquals(Http3Error.QPACK_ENCODER_STREAM_ERROR,
+                                decoderErrorHandler.http3Error.get());
 
         // It is expected that http3 error reported to
         // the decoder error handler only
-        Assert.assertNull(encoderErrorHandler.http3Error.get());
+        Assertions.assertNull(encoderErrorHandler.http3Error.get());
     }
 
     @Test
@@ -208,13 +208,13 @@ public class EncoderDecoderConnectionTest {
         System.err.println("Decoder Http3 error: " + decoderHttp3Error);
 
         if (encoderError == null || !(encoderError instanceof IOException)) {
-            Assert.fail("Incorrect encoder error type", encoderError);
+            Assertions.fail("Incorrect encoder error type", encoderError);
         }
         if (decoderError == null || !(decoderError instanceof IOException)) {
-            Assert.fail("Incorrect decoder error type", decoderError);
+            Assertions.fail("Incorrect decoder error type", decoderError);
         }
-        Assert.assertEquals(encoderHttp3Error, Http3Error.QPACK_DECODER_STREAM_ERROR);
-        Assert.assertEquals(decoderHttp3Error, Http3Error.QPACK_ENCODER_STREAM_ERROR);
+        Assertions.assertEquals(Http3Error.QPACK_DECODER_STREAM_ERROR, encoderHttp3Error);
+        Assertions.assertEquals(Http3Error.QPACK_ENCODER_STREAM_ERROR, decoderHttp3Error);
     }
 
     private static ByteBuffer instructionWithOverflowInteger(int N, int payload) {

--- a/test/jdk/java/net/httpclient/qpack/EncoderDecoderConnector.java
+++ b/test/jdk/java/net/httpclient/qpack/EncoderDecoderConnector.java
@@ -44,7 +44,6 @@ import jdk.internal.net.http.quic.streams.QuicSenderStream;
 import jdk.internal.net.http.quic.streams.QuicStream;
 import jdk.internal.net.http.quic.streams.QuicStreamWriter;
 import jdk.internal.net.quic.QuicTLSEngine;
-import org.testng.Assert;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -58,6 +57,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Instance of this class provides a stubbed Quic Connection implementation that
@@ -175,7 +175,7 @@ public class EncoderDecoderConnector {
         try {
             return MethodHandles.privateLookupIn(clz, MethodHandles.lookup());
         } catch (IllegalAccessException e) {
-            Assert.fail("Failed to initialize private Lookup instance", e);
+            Assertions.fail("Failed to initialize private Lookup instance", e);
             return null;
         }
     }
@@ -185,7 +185,7 @@ public class EncoderDecoderConnector {
         try {
             return lookup.findVarHandle(recv, "dynamicTable", DynamicTable.class);
         } catch (Exception e) {
-            Assert.fail("Failed to acquire dynamic table VarHandle instance", e);
+            Assertions.fail("Failed to acquire dynamic table VarHandle instance", e);
             return null;
         }
     }

--- a/test/jdk/java/net/httpclient/qpack/EntriesEvictionTest.java
+++ b/test/jdk/java/net/httpclient/qpack/EntriesEvictionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@
  *          java.net.http/jdk.internal.net.http.http3.streams
  *          java.net.http/jdk.internal.net.http.http3.frames
  *          java.net.http/jdk.internal.net.http.http3
- * @run testng/othervm -Djdk.internal.httpclient.qpack.log.level=EXTRA EntriesEvictionTest
+ * @run junit/othervm -Djdk.internal.httpclient.qpack.log.level=EXTRA EntriesEvictionTest
  */
 
 import java.util.ArrayList;
@@ -47,13 +47,16 @@ import jdk.internal.net.http.qpack.Encoder.SectionReference;
 import jdk.internal.net.http.qpack.HeaderField;
 import jdk.internal.net.http.qpack.QPACK;
 import jdk.internal.net.http.qpack.QPACK.Logger;
-import org.testng.Assert;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class EntriesEvictionTest {
 
-    @Test(dataProvider = "evictionScenarios")
+    @ParameterizedTest
+    @MethodSource("evictionScenarios")
     public void evictionInsertionTest(TestHeader headerToAdd,
                                       SectionReference sectionReference,
                                       long insertedId,
@@ -71,12 +74,12 @@ public class EntriesEvictionTest {
         // Insert last entry
         long id = dynamicTable.insert(headerToAdd.name, headerToAdd.value, sectionReference);
 
-        Assert.assertEquals(id, insertedId);
+        Assertions.assertEquals(insertedId, id);
 
         if (largestEvictedId != -1) {
             // Check that evicted entry with the largest absolute index
             // is not accessible
-            Assert.assertThrows(() -> dynamicTable.get(largestEvictedId));
+            Assertions.assertThrows(Throwable.class, () -> dynamicTable.get(largestEvictedId));
             // Check that an entry after that can be acquired with its
             // absolute index
             dynamicTable.get(largestEvictedId + 1);
@@ -84,12 +87,11 @@ public class EntriesEvictionTest {
 
         if (insertedId != -1) {
             HeaderField insertedField = dynamicTable.get(insertedId);
-            Assert.assertEquals(insertedField,
-                    new HeaderField(headerToAdd.name(), headerToAdd.value()));
+            Assertions.assertEquals(new HeaderField(headerToAdd.name(), headerToAdd.value()),
+                                    insertedField);
         }
     }
 
-    @DataProvider
     public static Object[][] evictionScenarios() {
 
         // Header that requires only one entry to be evicted

--- a/test/jdk/java/net/httpclient/qpack/StaticTableFieldsTest.java
+++ b/test/jdk/java/net/httpclient/qpack/StaticTableFieldsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,21 +24,23 @@
 /*
  * @test
  * @modules java.net.http/jdk.internal.net.http.qpack
- * @run testng/othervm -Djdk.internal.httpclient.qpack.log.level=NORMAL StaticTableFieldsTest
+ * @run junit/othervm -Djdk.internal.httpclient.qpack.log.level=NORMAL StaticTableFieldsTest
  */
 
 import jdk.internal.net.http.qpack.StaticTable;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class StaticTableFieldsTest {
 
-    @BeforeTest
+    @BeforeAll
     public void setUp() {
         // Populate expected table as defined by RFC
         expectedTable = new ArrayList<>();
@@ -66,10 +68,10 @@ public class StaticTableFieldsTest {
 
     @Test
     public void testStaticTable() {
-        assertEquals(actualTable.size(), expectedTable.size());
+        assertEquals(expectedTable.size(), actualTable.size());
         for (int i = 0; i < expectedTable.size(); i++) {
-            assertEquals(actualTable.get(i).name(), expectedTable.get(i).name());
-            assertEquals(actualTable.get(i).value(), expectedTable.get(i).value());
+            assertEquals(expectedTable.get(i).name(), actualTable.get(i).name());
+            assertEquals(expectedTable.get(i).value(), actualTable.get(i).value());
         }
     }
 

--- a/test/jdk/java/net/httpclient/qpack/UnacknowledgedInsertionTest.java
+++ b/test/jdk/java/net/httpclient/qpack/UnacknowledgedInsertionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,6 @@ import jdk.internal.net.http.http3.Http3Error;
 import jdk.internal.net.http.http3.frames.SettingsFrame;
 import jdk.internal.net.http.qpack.DecodingCallback;
 import jdk.internal.net.http.qpack.Encoder;
-import org.testng.Assert;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -38,7 +35,11 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.testng.Assert.assertNotEquals;
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /*
  * @test
@@ -56,11 +57,13 @@ import static org.testng.Assert.assertNotEquals;
  *          java.net.http/jdk.internal.net.http.http3.frames
  *          java.net.http/jdk.internal.net.http.http3
  * @build EncoderDecoderConnector
- * @run testng/othervm -Djdk.internal.httpclient.qpack.log.level=EXTRA UnacknowledgedInsertionTest
+ * @run junit/othervm -Djdk.internal.httpclient.qpack.log.level=EXTRA UnacknowledgedInsertionTest
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class UnacknowledgedInsertionTest {
 
-    @Test(dataProvider = "duplicateEntryInsertions")
+    @ParameterizedTest
+    @MethodSource("duplicateEntryInsertionsData")
     public void unacknowledgedDoubleInsertion(long knownReceiveCount, List<EncodingType> expectedHeadersEncodingType) throws Exception {
         // When knownReceiveCount is set to -1 the Encoder.knownReceiveCount()
         // value is used to encode headers - otherwise the provided value is used
@@ -101,10 +104,10 @@ public class UnacknowledgedInsertionTest {
         }
 
         // Only two entries are expected to be inserted to the dynamic table
-        Assert.assertEquals(ed.decoderTable().insertCount(), 2);
+        Assertions.assertEquals(2, ed.decoderTable().insertCount());
 
         // Check that headers byte buffer is not empty
-        assertNotEquals(headersBb.position(), 0);
+        assertNotEquals(0, headersBb.position());
         headersBb.flip();
         buffers.add(headersBb);
 
@@ -119,11 +122,10 @@ public class UnacknowledgedInsertionTest {
                 .stream()
                 .map(DecodedHeader::encodingType)
                 .toList();
-        Assert.assertEquals(actualHeaderEncodingTypes, expectedHeadersEncodingType);
+        Assertions.assertEquals(expectedHeadersEncodingType, actualHeaderEncodingTypes);
     }
 
 
-    @DataProvider(name = "duplicateEntryInsertions")
     private Object[][] duplicateEntryInsertionsData() {
         return new Object[][]{
                 {0, List.of(EncodingType.LITERAL, EncodingType.LITERAL, EncodingType.LITERAL)},
@@ -167,7 +169,7 @@ public class UnacknowledgedInsertionTest {
 
         @Override
         public void onDecoded(CharSequence name, CharSequence value) {
-            Assert.fail("onDecoded not expected to be called");
+            Assertions.fail("onDecoded not expected to be called");
         }
 
         @Override


### PR DESCRIPTION
Clean Backport. Tests passed with the changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8373808](https://bugs.openjdk.org/browse/JDK-8373808) needs maintainer approval

### Issue
 * [JDK-8373808](https://bugs.openjdk.org/browse/JDK-8373808): Refactor java/net/httpclient qpack and hpack tests to use JUnit (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/32/head:pull/32` \
`$ git checkout pull/32`

Update a local copy of the PR: \
`$ git checkout pull/32` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/32/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32`

View PR using the GUI difftool: \
`$ git pr show -t 32`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/32.diff">https://git.openjdk.org/jdk26u/pull/32.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/32#issuecomment-3806057453)
</details>
