### PR TITLE
8373650: Test "javax/swing/JMenuItem/6458123/ManualBug6458123.java" fails because the check icons are not aligned properly as expected

### DIFF
--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsIconFactory.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsIconFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -905,10 +905,46 @@ public final class WindowsIconFactory implements Serializable
                         XPStyle xp = XPStyle.getXP();
                         if (xp != null) {
                             Skin skin = xp.getSkin(c, part);
-                            if (icon == null || icon.getIconHeight() <= 16) {
-                                skin.paintSkin(g, x + OFFSET, y + OFFSET, state);
+                            if (WindowsGraphicsUtils.isLeftToRight(c)) {
+                                if (icon == null || icon.getIconHeight() <= 16) {
+                                    skin.paintSkin(g, x + OFFSET, y + OFFSET, state);
+                                } else {
+                                    skin.paintSkin(g, x + OFFSET, y + icon.getIconHeight() / 2, state);
+                                }
                             } else {
-                                skin.paintSkin(g, x + OFFSET, y + icon.getIconHeight() / 2, state);
+                                if (icon == null) {
+                                    skin.paintSkin(g, x + 4 * OFFSET, y + OFFSET, state);
+                                } else {
+                                    int ycoord = (icon.getIconHeight() <= 16)
+                                                  ? y + OFFSET
+                                                  : (y + icon.getIconHeight() / 2);
+                                    if (icon.getIconWidth() <= 8) {
+                                        skin.paintSkin(g, x + OFFSET, ycoord, state);
+                                    } else if (icon.getIconWidth() <= 16) {
+                                        if (menuItem.getText().isEmpty()) {
+                                            skin.paintSkin(g,
+                                                (menuItem.getAccelerator() != null)
+                                                 ? (x + 2 * OFFSET) : (x + 3 * OFFSET),
+                                                ycoord, state);
+                                        } else {
+                                            skin.paintSkin(g,
+                                                (type == JRadioButtonMenuItem.class)
+                                                 ? (x + 4 * OFFSET) : (x + 3 * OFFSET),
+                                                ycoord, state);
+                                        }
+                                    } else {
+                                        if (menuItem.getText().isEmpty()
+                                            || menuItem.getAccelerator() != null) {
+                                            skin.paintSkin(g,
+                                                (type == JRadioButtonMenuItem.class)
+                                                 ? (x + 3 * OFFSET) : (x + 4 * OFFSET),
+                                                ycoord, state);
+                                        } else {
+                                            skin.paintSkin(g, x + 7 * OFFSET,
+                                                           ycoord, state);
+                                        }
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [e45f5656](https://github.com/openjdk/jdk/commit/e45f5656bc90421c9acb0cbf87164162039ddf81) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Prasanta Sadhukhan on 20 Jan 2026 and was reviewed by Tejesh R and Damon Nguyen.

Thanks,
Anupam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8373650](https://bugs.openjdk.org/browse/JDK-8373650) needs maintainer approval

### Issue
 * [JDK-8373650](https://bugs.openjdk.org/browse/JDK-8373650): Test "javax/swing/JMenuItem/6458123/ManualBug6458123.java" fails because the check icons are not aligned properly as expected (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/33/head:pull/33` \
`$ git checkout pull/33`

Update a local copy of the PR: \
`$ git checkout pull/33` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/33/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 33`

View PR using the GUI difftool: \
`$ git pr show -t 33`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/33.diff">https://git.openjdk.org/jdk26u/pull/33.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/33#issuecomment-3812353464)
</details>
