### PR TITLE
8373931: Test javax/sound/sampled/Clip/AutoCloseTimeCheck.java timed out

### DIFF
--- a/test/jdk/javax/sound/sampled/Clip/AutoCloseTimeCheck.java
+++ b/test/jdk/javax/sound/sampled/Clip/AutoCloseTimeCheck.java
@@ -39,6 +39,7 @@ import static javax.sound.sampled.AudioSystem.NOT_SPECIFIED;
 
 /**
  * @test
+ * @key sound
  * @bug 8202264
  */
 public final class AutoCloseTimeCheck {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [f3121d10](https://github.com/openjdk/jdk/commit/f3121d10237a933087dde926f83a12ce826cde02) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Phil Race on 22 Jan 2026 and was reviewed by David Holmes, Damon Nguyen and Alexander Zuev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8373931](https://bugs.openjdk.org/browse/JDK-8373931) needs maintainer approval

### Issue
 * [JDK-8373931](https://bugs.openjdk.org/browse/JDK-8373931): Test javax/sound/sampled/Clip/AutoCloseTimeCheck.java timed out (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/35.diff">https://git.openjdk.org/jdk26u/pull/35.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/35#issuecomment-3822047320)
</details>
