### PR TITLE
8373362: Http3TestServer should not log an exception stack trace when it is stopping normally

### DIFF
--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http3/Http3ServerExchange.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http3/Http3ServerExchange.java
@@ -108,6 +108,11 @@ public final class Http3ServerExchange implements Http2TestExchange {
         rspheadersBuilder = new HttpHeadersBuilder();
     }
 
+    Http3ServerConnection http3Connection() {
+        return serverConn;
+    }
+
+
     String connectionTag() {
         return serverConn.quicConnection().logTag();
     }


### PR DESCRIPTION
Clean Backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8373362](https://bugs.openjdk.org/browse/JDK-8373362) needs maintainer approval

### Issue
 * [JDK-8373362](https://bugs.openjdk.org/browse/JDK-8373362): Http3TestServer should not log an exception stack trace when it is stopping normally (**Bug** - P4 - Approved)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/36.diff">https://git.openjdk.org/jdk26u/pull/36.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/36#issuecomment-3824717818)
</details>
