### PR TITLE
8374506: Incorrect positioning of arrow icon in parent JMenu in Windows L&F

### DIFF
--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuItemUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuItemUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -238,6 +238,15 @@ public final class WindowsMenuItemUI extends BasicMenuItemUI {
         SwingUtilities3.paintAccText(g, lh, lr, disabledForeground,
                                      acceleratorSelectionForeground,
                                      acceleratorForeground);
+        if (lh.getCheckIcon() != null && lh.useCheckAndArrow()) {
+            Rectangle rect = lr.getArrowRect();
+            if (menuItem.getComponentOrientation().isLeftToRight()) {
+                rect.x += lh.getAfterCheckIconGap();
+            } else {
+                rect.x -= lh.getAfterCheckIconGap();
+            }
+            lr.setArrowRect(rect);
+        }
         SwingUtilities3.paintArrowIcon(g, lh, lr, foreground);
 
         // Restore original graphics font and color

--- a/test/jdk/javax/swing/JMenuItem/LargeMenuTextArrowIconPosition.java
+++ b/test/jdk/javax/swing/JMenuItem/LargeMenuTextArrowIconPosition.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8374506
+ * @summary Verify if arrow icon positioning is correct in
+ *          parent JMenu in Windows L&F
+ * @requires (os.family == "windows")
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual LargeMenuTextArrowIconPosition
+ */
+
+import java.awt.BorderLayout;
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.UIManager;
+
+public class LargeMenuTextArrowIconPosition {
+
+    private static final String INSTRUCTIONS = """
+        A frame will be shown with a label.
+        Right click on the label.
+
+        Check the arrow icon at the end of
+        "Really long Menu-Text" text.
+        If it overlaps with the menu text,
+        press Fail else press Pass.""";
+
+    public static void main(String[] args) throws Throwable {
+        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+
+         PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(LargeMenuTextArrowIconPosition::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+
+        JFrame frame = new JFrame("LargeMenuTextArrowIcon");
+        frame.setSize(300, 150);
+        frame.setLayout(new BorderLayout());
+
+        JPopupMenu popupMenu = new JPopupMenu();
+        popupMenu.add(new JCheckBoxMenuItem("CheckBox On", true));
+        popupMenu.add(new JCheckBoxMenuItem("CheckBox Icon On",
+                          UIManager.getIcon("FileView.floppyDriveIcon"), true));
+        popupMenu.add(new JCheckBoxMenuItem("CheckBox Icon Off",
+                          UIManager.getIcon("FileView.floppyDriveIcon"), false));
+
+        JMenu menu = new JMenu("Really long Menu-Text");
+        menu.add(new JMenuItem("Sub-MenuItem"));
+        menu.add(new JCheckBoxMenuItem("Sub-CheckBox On", true));
+
+        popupMenu.add(menu);
+
+        JLabel lbl = new JLabel("Right click to invoke popupMenu");
+        lbl.setComponentPopupMenu(popupMenu);
+        frame.add(lbl, BorderLayout.CENTER);
+
+        return frame;
+    }
+
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [9a10ccee](https://github.com/openjdk/jdk/commit/9a10cceeafa5d332aa571f0d62acf50032a597d4) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Prasanta Sadhukhan on 30 Jan 2026 and was reviewed by Alexey Ivanov and Alexander Zuev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8374506](https://bugs.openjdk.org/browse/JDK-8374506) needs maintainer approval

### Issue
 * [JDK-8374506](https://bugs.openjdk.org/browse/JDK-8374506): Incorrect positioning of arrow icon in parent JMenu in Windows L&amp;F (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/38.diff">https://git.openjdk.org/jdk26u/pull/38.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/38#issuecomment-3847051933)
</details>
