### PR TITLE
8375598: VM crashes with "assert((labs(val) & 0xFFFFFFFF00000000) == 0 || dest == (address)-1) failed: must be 32bit offset or -1" when using too high value for NonNMethodCodeHeapSize

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,13 +248,61 @@ void CodeCache::initialize_heaps() {
     set_size_of_unset_code_heap(&non_nmethod, cache_size, profiled.size + non_profiled.size, non_nmethod_min_size);
   }
 
-  size_t total = non_nmethod.size + profiled.size + non_profiled.size;
-  if (total != cache_size && !cache_size_set) {
-    log_info(codecache)("ReservedCodeCache size %zuK changed to total segments size NonNMethod "
-                        "%zuK NonProfiled %zuK Profiled %zuK = %zuK",
-                        cache_size/K, non_nmethod.size/K, non_profiled.size/K, profiled.size/K, total/K);
-    // Adjust ReservedCodeCacheSize as necessary because it was not set explicitly
-    cache_size = total;
+  // Note: if large page support is enabled, min_size is at least the large
+  // page size. This ensures that the code cache is covered by large pages.
+  non_nmethod.size = align_up(non_nmethod.size, min_size);
+  profiled.size = align_up(profiled.size, min_size);
+  non_profiled.size = align_up(non_profiled.size, min_size);
+
+  size_t aligned_total = non_nmethod.size + profiled.size + non_profiled.size;
+  if (!cache_size_set) {
+    // If ReservedCodeCacheSize is explicitly set and exceeds CODE_CACHE_SIZE_LIMIT,
+    // it is rejected by flag validation elsewhere. Here we only handle the case
+    // where ReservedCodeCacheSize is not set explicitly, but the computed segmented
+    // sizes (after alignment) exceed the platform limit.
+    if (aligned_total > CODE_CACHE_SIZE_LIMIT) {
+      err_msg message("ReservedCodeCacheSize (%zuK), Max (%zuK)."
+                      "Segments: NonNMethod (%zuK), NonProfiled (%zuK), Profiled (%zuK).",
+                      aligned_total/K, CODE_CACHE_SIZE_LIMIT/K,
+                      non_nmethod.size/K, non_profiled.size/K, profiled.size/K);
+      vm_exit_during_initialization("Code cache size exceeds platform limit", message);
+    }
+    if (aligned_total != cache_size) {
+      log_info(codecache)("ReservedCodeCache size %zuK changed to total segments size NonNMethod "
+                          "%zuK NonProfiled %zuK Profiled %zuK = %zuK",
+                          cache_size/K, non_nmethod.size/K, non_profiled.size/K, profiled.size/K, aligned_total/K);
+      // Adjust ReservedCodeCacheSize as necessary because it was not set explicitly
+      cache_size = aligned_total;
+    }
+  } else {
+    check_min_size("reserved code cache", cache_size, min_cache_size);
+    // ReservedCodeCacheSize was set explicitly, so treat it as a hard cap.
+    // If alignment causes the total to exceed the cap, shrink unset heaps
+    // in min_size steps, never below their minimum sizes.
+    //
+    // A total smaller than cache_size typically happens when all segment sizes
+    // are explicitly set. In that case there is nothing to adjust, so we
+    // only validate the sizes.
+    if (aligned_total > cache_size) {
+      size_t delta = (aligned_total - cache_size) / min_size;
+      while (delta > 0) {
+        size_t start_delta = delta;
+        // Do not shrink the non-nmethod heap here: running out of non-nmethod space
+        // is more critical and may lead to unrecoverable VM errors.
+        if (non_profiled.enabled && !non_profiled.set && non_profiled.size > min_size) {
+          non_profiled.size -= min_size;
+          if (--delta == 0) break;
+        }
+        if (profiled.enabled && !profiled.set && profiled.size > min_size) {
+          profiled.size -= min_size;
+          delta--;
+        }
+        if (delta == start_delta) {
+          break;
+        }
+      }
+      aligned_total = non_nmethod.size + profiled.size + non_profiled.size;
+    }
   }
 
   log_debug(codecache)("Initializing code heaps ReservedCodeCache %zuK NonNMethod %zuK"
@@ -270,12 +318,9 @@ void CodeCache::initialize_heaps() {
   if (non_profiled.enabled) { // non_profiled.enabled is always ON for segmented code heap, leave it checked for clarity
     check_min_size("non-profiled code heap", non_profiled.size, min_size);
   }
-  if (cache_size_set) {
-    check_min_size("reserved code cache", cache_size, min_cache_size);
-  }
 
   // ReservedCodeCacheSize was set explicitly, so report an error and abort if it doesn't match the segment sizes
-  if (total != cache_size && cache_size_set) {
+  if (aligned_total != cache_size && cache_size_set) {
     err_msg message("NonNMethodCodeHeapSize (%zuK)", non_nmethod.size/K);
     if (profiled.enabled) {
       message.append(" + ProfiledCodeHeapSize (%zuK)", profiled.size/K);
@@ -283,8 +328,8 @@ void CodeCache::initialize_heaps() {
     if (non_profiled.enabled) {
       message.append(" + NonProfiledCodeHeapSize (%zuK)", non_profiled.size/K);
     }
-    message.append(" = %zuK", total/K);
-    message.append((total > cache_size) ? " is greater than " : " is less than ");
+    message.append(" = %zuK", aligned_total/K);
+    message.append((aligned_total > cache_size) ? " is greater than " : " is less than ");
     message.append("ReservedCodeCacheSize (%zuK).", cache_size/K);
 
     vm_exit_during_initialization("Invalid code heap sizes", message);
@@ -299,13 +344,6 @@ void CodeCache::initialize_heaps() {
                              PROPERFMTARGS(lg_ps), PROPERFMTARGS(ps));
     }
   }
-
-  // Note: if large page support is enabled, min_size is at least the large
-  // page size. This ensures that the code cache is covered by large pages.
-  non_nmethod.size = align_up(non_nmethod.size, min_size);
-  profiled.size = align_up(profiled.size, min_size);
-  non_profiled.size = align_up(non_profiled.size, min_size);
-  cache_size = non_nmethod.size + profiled.size + non_profiled.size;
 
   FLAG_SET_ERGO(NonNMethodCodeHeapSize, non_nmethod.size);
   FLAG_SET_ERGO(ProfiledCodeHeapSize, profiled.size);

--- a/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test CheckSegmentedCodeCache
- * @bug 8015774
+ * @bug 8015774 8375598
  * @summary Checks VM options related to the segmented code cache
  * @library /test/lib
  * @requires vm.flagless
@@ -247,5 +247,12 @@ public class CheckSegmentedCodeCache {
                                                               "-XX:+PrintFlagsFinal",
                                                               "-version");
         verifyCodeHeapSize(pb, "NonNMethodCodeHeapSize", 83886080);
+
+        // A large NonNMethodCodeHeapSize can make the total code cache exceed the platform limit.
+        // The VM should fail fast during initialization.
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+SegmentedCodeCache",
+                                                              "-XX:NonNMethodCodeHeapSize=3G",
+                                                              "-version");
+        failsWith(pb, "Code cache size exceeds platform limit");
     }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [1efb2982](https://github.com/openjdk/jdk/commit/1efb29829fdd526be55c0a00420980279d9824ee) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Guanqiang Han on 6 Feb 2026 and was reviewed by Martin Doerr and Vladimir Kozlov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8375598](https://bugs.openjdk.org/browse/JDK-8375598) needs maintainer approval

### Issue
 * [JDK-8375598](https://bugs.openjdk.org/browse/JDK-8375598): VM crashes with "assert((labs(val) &amp; 0xFFFFFFFF00000000) == 0 || dest == (address)-1) failed: must be 32bit offset or -1" when using too high value for NonNMethodCodeHeapSize (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/41/head:pull/41` \
`$ git checkout pull/41`

Update a local copy of the PR: \
`$ git checkout pull/41` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/41/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 41`

View PR using the GUI difftool: \
`$ git pr show -t 41`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/41.diff">https://git.openjdk.org/jdk26u/pull/41.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/41#issuecomment-3864221880)
</details>
