### PR TITLE
8367994: test/jdk/sun/security/pkcs11/Signature/ tests pass when they should skip

### DIFF
--- a/test/jdk/sun/security/pkcs11/Signature/InitAgainPSS.java
+++ b/test/jdk/sun/security/pkcs11/Signature/InitAgainPSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,8 +20,15 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-import java.security.*;
-import java.security.spec.*;
+import jtreg.SkippedException;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Signature;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
 
 /**
  * @test
@@ -46,9 +53,7 @@ public class InitAgainPSS extends PKCS11Test {
         try {
             s1 = Signature.getInstance(sigAlg, p);
         } catch (NoSuchAlgorithmException e) {
-            System.out.println("Skip testing " + sigAlg +
-                " due to no support");
-            return;
+            throw new SkippedException("No support " + sigAlg);
         }
 
         byte[] msg = "hello".getBytes();

--- a/test/jdk/sun/security/pkcs11/Signature/SigInteropPSS.java
+++ b/test/jdk/sun/security/pkcs11/Signature/SigInteropPSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,9 +21,15 @@
  * questions.
  */
 
-import java.security.*;
-import java.security.spec.*;
-import java.security.interfaces.*;
+import jtreg.SkippedException;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Signature;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
 
 /*
  * @test
@@ -53,9 +59,7 @@ public class SigInteropPSS extends PKCS11Test {
         try {
             sigPkcs11 = Signature.getInstance("RSASSA-PSS", p);
         } catch (NoSuchAlgorithmException e) {
-            System.out.println("Skip testing RSASSA-PSS" +
-                " due to no support");
-            return;
+            throw new SkippedException("No support for RSASSA-PSS");
         }
 
         Signature sigSunRsaSign =

--- a/test/jdk/sun/security/pkcs11/Signature/SigInteropPSS2.java
+++ b/test/jdk/sun/security/pkcs11/Signature/SigInteropPSS2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,9 +21,16 @@
  * questions.
  */
 
-import java.security.*;
-import java.security.spec.*;
-import java.security.interfaces.*;
+import jtreg.SkippedException;
+
+import java.security.AlgorithmParameters;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
+import java.security.Signature;
+import java.security.spec.PSSParameterSpec;
 
 /*
  * @test
@@ -67,9 +74,7 @@ public class SigInteropPSS2 extends PKCS11Test {
             try {
                 sigPkcs11 = Signature.getInstance(digest + "withRSASSA-PSS", p);
             } catch (NoSuchAlgorithmException e) {
-                System.out.println("Skip testing " + digest + "withRSASSA-PSS" +
-                    " due to no support");
-                continue;
+                throw new SkippedException("No support for " + digest + "withRSASSA-PSS");
             }
 
             runTest(sigPkcs11, sigSunRsaSign, kp);

--- a/test/jdk/sun/security/pkcs11/Signature/TestDSA.java
+++ b/test/jdk/sun/security/pkcs11/Signature/TestDSA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  * @modules jdk.crypto.cryptoki
  * @run main/othervm TestDSA
  */
+
+import jtreg.SkippedException;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -122,8 +124,7 @@ public class TestDSA extends PKCS11Test {
         System.out.println("Testing provider " + provider + "...");
 
         if (provider.getService("Signature", "SHA1withDSA") == null) {
-            System.out.println("DSA not supported, skipping");
-            return;
+            throw new SkippedException("DSA not supported");
         }
 
         KeyFactory kf = KeyFactory.getInstance("DSA", provider);


### PR DESCRIPTION
Straight Backport.Ran the tests. Looks good

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8367994](https://bugs.openjdk.org/browse/JDK-8367994) needs maintainer approval

### Issue
 * [JDK-8367994](https://bugs.openjdk.org/browse/JDK-8367994): test/jdk/sun/security/pkcs11/Signature/ tests pass when they should skip (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/46/head:pull/46` \
`$ git checkout pull/46`

Update a local copy of the PR: \
`$ git checkout pull/46` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/46/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 46`

View PR using the GUI difftool: \
`$ git pr show -t 46`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/46.diff">https://git.openjdk.org/jdk26u/pull/46.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/46#issuecomment-3878456572)
</details>
