### PR TITLE
8374056: RISC-V: Fix argument passing for the RiscvFlushIcache::flush

### DIFF
--- a/src/hotspot/cpu/riscv/icache_riscv.cpp
+++ b/src/hotspot/cpu/riscv/icache_riscv.cpp
@@ -39,7 +39,8 @@ static int icache_flush(address addr, int lines, int magic) {
   // We need to make sure stores happens before the I/D cache synchronization.
   __asm__ volatile("fence rw, rw" : : : "memory");
 
-  RiscvFlushIcache::flush((uintptr_t)addr, ((uintptr_t)lines) << ICache::log2_line_size);
+  uintptr_t end = (uintptr_t)addr + ((uintptr_t)lines << ICache::log2_line_size);
+  RiscvFlushIcache::flush((uintptr_t)addr, end);
 
   return magic;
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [dc80ce7a](https://github.com/openjdk/jdk/commit/dc80ce7aec8e466a29fd4c94ee70c90a7244869f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by ikarostsin on 9 Feb 2026 and was reviewed by Fei Yang and Robbin Ehn.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8374056](https://bugs.openjdk.org/browse/JDK-8374056) needs maintainer approval

### Issue
 * [JDK-8374056](https://bugs.openjdk.org/browse/JDK-8374056): RISC-V: Fix argument passing for the RiscvFlushIcache::flush (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/48/head:pull/48` \
`$ git checkout pull/48`

Update a local copy of the PR: \
`$ git checkout pull/48` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/48/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 48`

View PR using the GUI difftool: \
`$ git pr show -t 48`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/48.diff">https://git.openjdk.org/jdk26u/pull/48.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/48#issuecomment-3884028976)
</details>
