### PR TITLE
8297191: [macos] Printing a page range with starting page > 1 results in missing pages

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -355,20 +355,9 @@ public final class CPrinterJob extends RasterPrinterJob {
             validateDestination(destinationAttr);
         }
 
-        /* Get the range of pages we are to print. If the
-         * last page to print is unknown, then we print to
-         * the end of the document. Note that firstPage
-         * and lastPage are 0 based page indices.
-         */
-
+        // Note that firstPage is 0 based page index.
         int firstPage = getFirstPage();
-        int lastPage = getLastPage();
-        if(lastPage == Pageable.UNKNOWN_NUMBER_OF_PAGES) {
-            int totalPages = mDocument.getNumberOfPages();
-            if (totalPages != Pageable.UNKNOWN_NUMBER_OF_PAGES) {
-                lastPage = mDocument.getNumberOfPages() - 1;
-            }
-        }
+        int totalPages = mDocument.getNumberOfPages();
 
         try {
             synchronized (this) {
@@ -393,7 +382,7 @@ public final class CPrinterJob extends RasterPrinterJob {
                     try {
                         // Fire off the print rendering loop on the AppKit thread, and don't have
                         //  it wait and block this thread.
-                        if (printLoop(false, firstPage, lastPage)) {
+                        if (printLoop(false, firstPage, totalPages)) {
                             // Start a secondary loop on EDT until printing operation is finished or cancelled
                             printingLoop.enter();
                         }
@@ -407,7 +396,7 @@ public final class CPrinterJob extends RasterPrinterJob {
                     onEventThread = false;
 
                     try {
-                        printLoop(true, firstPage, lastPage);
+                        printLoop(true, firstPage, totalPages);
                     } catch (Exception e) {
                         e.printStackTrace();
                     }
@@ -417,7 +406,6 @@ public final class CPrinterJob extends RasterPrinterJob {
                 }
                 if (++loopi < prMembers.length) {
                      firstPage = prMembers[loopi][0]-1;
-                     lastPage = prMembers[loopi][1] -1;
                 }
             }  while (loopi < prMembers.length);
         } finally {
@@ -693,7 +681,7 @@ public final class CPrinterJob extends RasterPrinterJob {
         }
     }
 
-    private native boolean printLoop(boolean waitUntilDone, int firstPage, int lastPage) throws PrinterException;
+    private native boolean printLoop(boolean waitUntilDone, int firstPage, int totalPages) throws PrinterException;
 
     private PageFormat getPageFormat(int pageIndex) {
         // This is called from the native side.

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -656,7 +656,7 @@ JNI_COCOA_EXIT(env);
  * Signature: ()V
  */
 JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_CPrinterJob_printLoop
-  (JNIEnv *env, jobject jthis, jboolean blocks, jint firstPage, jint lastPage)
+  (JNIEnv *env, jobject jthis, jboolean blocks, jint firstPage, jint totalPages)
 {
     AWT_ASSERT_NOT_APPKIT_THREAD;
 
@@ -672,14 +672,14 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_CPrinterJob_printLoop
 JNI_COCOA_ENTER(env);
     // Get the first page's PageFormat for setting things up (This introduces
     //  and is a facet of the same problem in Radar 2818593/2708932).
-    jobject page = (*env)->CallObjectMethod(env, jthis, jm_getPageFormat, 0); // AWT_THREADING Safe (!appKit)
+    jobject page = (*env)->CallObjectMethod(env, jthis, jm_getPageFormat, firstPage); // AWT_THREADING Safe (!appKit)
     CHECK_EXCEPTION();
     if (page != NULL) {
         jobject pageFormatArea = (*env)->CallObjectMethod(env, jthis, jm_getPageFormatArea, page); // AWT_THREADING Safe (!appKit)
         CHECK_EXCEPTION();
 
         PrinterView* printerView = [[PrinterView alloc] initWithFrame:JavaToNSRect(env, pageFormatArea) withEnv:env withPrinterJob:jthis];
-        [printerView setFirstPage:firstPage lastPage:lastPage];
+        [printerView setTotalPages:totalPages];
 
         GET_NSPRINTINFO_METHOD_RETURN(NO)
         NSPrintInfo* printInfo = (NSPrintInfo*)jlong_to_ptr((*env)->CallLongMethod(env, jthis, sjm_getNSPrintInfo)); // AWT_THREADING Safe (known object)

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/PrinterView.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/PrinterView.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,12 +32,12 @@
     jobject fCurPainter;
     jobject fCurPeekGraphics;
 
-    jint fFirstPage, fLastPage;
+    jint fTotalPages;
 }
 
 - (id)initWithFrame:(NSRect)aRect withEnv:(JNIEnv*)env withPrinterJob:(jobject)printerJob;
 
-- (void)setFirstPage:(jint)firstPage lastPage:(jint)lastPage;
+- (void)setTotalPages:(jint)totalPages;
 
 - (void)releaseReferences:(JNIEnv*)env;
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/PrinterView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/PrinterView.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,9 +72,8 @@ static jclass sjc_PAbortEx = NULL;
     }
 }
 
-- (void)setFirstPage:(jint)firstPage lastPage:(jint)lastPage {
-    fFirstPage = firstPage;
-    fLastPage = lastPage;
+- (void)setTotalPages:(jint)totalPages {
+    fTotalPages = totalPages;
 }
 
 - (void)drawRect:(NSRect)aRect
@@ -156,15 +155,15 @@ static jclass sjc_PAbortEx = NULL;
         return NO;
     }
 
-    aRange->location = fFirstPage + 1;
+    aRange->location = 1;
 
-    if (fLastPage == java_awt_print_Pageable_UNKNOWN_NUMBER_OF_PAGES)
+    if (fTotalPages == java_awt_print_Pageable_UNKNOWN_NUMBER_OF_PAGES)
     {
         aRange->length = NSIntegerMax;
     }
     else
     {
-        aRange->length = (fLastPage + 1) - fFirstPage;
+        aRange->length = fTotalPages;
     }
 
     return YES;

--- a/test/jdk/java/awt/print/PrinterJob/PageRanges.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageRanges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6575331
+ * @bug 6575331 8297191
  * @key printer
  * @summary The specified pages should be printed.
  * @library /java/awt/regtesthelpers


### PR DESCRIPTION
Backporting [8297191](https://bugs.openjdk.org/browse/JDK-8297191): *\[macos\] Printing a page range with starting page > 1 results in missing pages*

The patch applies *cleanly* except for copyright year in `CPrinterJob.m`.

I verified the fix with the automatic test, `PageRangesAuto.java`, which will be added to JDK with [JDK-8377602](https://bugs.openjdk.org/browse/JDK-8377602).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8297191](https://bugs.openjdk.org/browse/JDK-8297191) needs maintainer approval

### Issue
 * [JDK-8297191](https://bugs.openjdk.org/browse/JDK-8297191): [macos] Printing a page range with starting page &gt; 1 results in missing pages (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/49/head:pull/49` \
`$ git checkout pull/49`

Update a local copy of the PR: \
`$ git checkout pull/49` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/49/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 49`

View PR using the GUI difftool: \
`$ git pr show -t 49`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/49.diff">https://git.openjdk.org/jdk26u/pull/49.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/49#issuecomment-3887241485)
</details>
