### PR TITLE
8068378: [TEST_BUG]The java/awt/Modal/PrintDialogsTest/PrintDialogsTest.java instruction need to update

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -781,7 +781,6 @@ java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter_1.java 7131438,802
 java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter_2.java 7131438,8022539 generic-all
 java/awt/Modal/WsDisabledStyle/CloseBlocker/CloseBlocker.java 7187741 linux-all,macosx-all
 java/awt/xembed/server/TestXEmbedServerJava.java 8001150,8004031 generic-all
-java/awt/Modal/PrintDialogsTest/PrintDialogsTest.java 8068378 generic-all
 java/awt/image/VolatileImage/VolatileImageConfigurationTest.java 8171069 macosx-all,linux-all
 java/awt/Modal/InvisibleParentTest/InvisibleParentTest.java 8172245 linux-all
 java/awt/Frame/FrameStateTest/FrameStateTest.java 8203920 macosx-all,linux-all

--- a/test/jdk/java/awt/Modal/PrintDialogsTest/PrintDialogsTest.java
+++ b/test/jdk/java/awt/Modal/PrintDialogsTest/PrintDialogsTest.java
@@ -49,40 +49,35 @@ import java.awt.event.ActionListener;
 
 public class PrintDialogsTest extends Panel implements ActionListener {
 
-    static final String INSTRUCTIONS = """
-        This test is free format, which means there is no enforced or guided sequence.
-
-        Please select each of
-        (a) The dialog parent type.
-        (b) The dialog modality type
-        (c) The print dialog type (Print dialog or Page Setup dialog)
-
-        Once the choices have been made click the "Start test" button.
-
-        Three windows will appear
-        (1) A Frame or a Dialog - in the case you selected "Dialog" as the parent type
-        (2) a Window (ie an undecorated top-level)
-        (3) A dialog with two buttons "Open" and "Finish"
-
-        Now check as follows whether modal blocking works as expected.
-        Windows (1) and (2) contain a button which you should be able to press
-        ONLY if you selected "Non-modal", or "Modeless" for modality type.
-        In other cases window (3) will block input to (1) and (2)
-
-        Then push the "Open" button on the Dialog to show the printing dialog and check
-        if it blocks the rest of the application - ie all of windows (1), (2) and (3)
-        should ALWAYS be blocked when the print dialog is showing.
-        Now cancel the printing dialog and check the correctness of modal blocking
-        behavior for the Dialog again.
-        To close all the 3 test windows please push the "Finish" button.
-
-        Repeat all the above for different combinations, which should include
-        using all of the Dialog parent choices and all of the Dialog Modality types.
-
-        If any behave incorrectly, note the combination of choices and press Fail.
-
-        If all behave correctly, press Pass.
-    """;
+    static final String INSTRUCTIONS =
+        "1. On the Test UI Select:\n" +
+        "\tThe dialog parent type. (e.g. Frame, Dialog, Hidden, Null)\n" +
+        "\tThe dialog modality type. (e.g. Modal, Non-Modal, Toolkit modal).\n" +
+        "\tThe print dialog type. (Print dialog or Page Setup dialog).\n\n" +
+        "2. Next, click on 'Start test' - Three windows will appear:\n" +
+        "\tWindow (1) -a Frame or Dialog (depending on selected parent type).\n" +
+        "\tWindow (2) -an undecorated top-level Window.\n" +
+        "\tWindow (3) -a Dialog containing two buttons: 'Open' and 'Finish'.\n" +
+        "\tWindows (1) & (2) have a Dummy button.\n\n" +
+        "3. Press the button on Window (1) & Window (2) \n" +
+        "Verification step:\n" +
+        "\tIf Modality is 'Non-modal' or 'Modeless', Button is pressed \n" +
+        "\tIf Modality is 'Document' & parent is not Frame/Dialog, Button is pressed \n" +
+        "\tIn all other cases, button is not pressed & Window (3) should \n" +
+        "\tblock input to Windows (1) & (2).\n\n" +
+        "4. Next, press the 'Open' button in Window (3) to open print dialog.\n\n" +
+        "5. Press the button on Window (1) & Window (2)\n" +
+        "Verification step:\n" +
+        "\tThe print dialog should block all three windows (1, 2, and 3).\n\n" +
+        "6. Cancel the print dialog, Check again if Window (3) " +
+        "blocks Windows (1) and (2) correctly.\n" +
+        "Verification step:\n" +
+        "\tConditions as seen in Verification step 3 " +
+        "should be seen, as before.\n" +
+        "To close all test windows, press 'Finish'.\n\n" +
+        "7. Repeat the steps for different combinations of Dialog Parent, Dialog Modality Type, Print Dialg Type.\n" +
+        "Try every dialog parent type and every dialog modality type.\n\n" +
+        "If any of the Verification step fails, note the combination and press 'Fail'.\n";
 
     public static void main(String[] args) throws Exception {
 

--- a/test/jdk/java/awt/Modal/PrintDialogsTest/Test.java
+++ b/test/jdk/java/awt/Modal/PrintDialogsTest/Test.java
@@ -191,6 +191,7 @@ public class Test {
                 break;
             case DIALOG:
                 dialog = new CustomDialog(parent);
+                break;
             case FRAME:
                 dialog = new CustomDialog(frame);
                 break;


### PR DESCRIPTION
This is a backport of JDK-8068378 
Updated the test instructions for better clarity, formatting and removed its entry from the ProblemList.txt.
A missing break in a switch case block in Test.java was identified during testing of the fix. This was also fixed.

Code Changes
modified:   test/jdk/ProblemList.txt
modified:   test/jdk/java/awt/Modal/PrintDialogsTest/PrintDialogsTest.java
modified:   test/jdk/java/awt/Modal/PrintDialogsTest/Test.java

JTREG Testing - Test passed on manual run via JTreg Command.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8068378](https://bugs.openjdk.org/browse/JDK-8068378) needs maintainer approval

### Issue
 * [JDK-8068378](https://bugs.openjdk.org/browse/JDK-8068378): [TEST_BUG]The java/awt/Modal/PrintDialogsTest/PrintDialogsTest.java instruction need to update (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/51/head:pull/51` \
`$ git checkout pull/51`

Update a local copy of the PR: \
`$ git checkout pull/51` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/51/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 51`

View PR using the GUI difftool: \
`$ git pr show -t 51`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/51.diff">https://git.openjdk.org/jdk26u/pull/51.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/51#issuecomment-3895653729)
</details>
