### PR TITLE
8371503: RETAIN_IMAGE_AFTER_TEST do not work for some tests

### DIFF
--- a/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
+++ b/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
@@ -54,9 +54,7 @@ public class DockerBasicTest {
             testHelloDocker();
             testJavaVersionWithCgMounts();
         } finally {
-            if (!DockerTestUtils.RETAIN_IMAGE_AFTER_TEST) {
-                DockerTestUtils.removeDockerImage(imageNameAndTag);
-            }
+            DockerTestUtils.removeDockerImage(imageNameAndTag);
         }
     }
 

--- a/test/hotspot/jtreg/containers/docker/ShareTmpDir.java
+++ b/test/hotspot/jtreg/containers/docker/ShareTmpDir.java
@@ -57,9 +57,7 @@ public class ShareTmpDir {
         try {
             test();
         } finally {
-            if (!DockerTestUtils.RETAIN_IMAGE_AFTER_TEST) {
-                DockerTestUtils.removeDockerImage(imageName);
-            }
+            DockerTestUtils.removeDockerImage(imageName);
         }
     }
 

--- a/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
@@ -85,9 +85,7 @@ public class TestCPUAwareness {
             }
 
         } finally {
-            if (!DockerTestUtils.RETAIN_IMAGE_AFTER_TEST) {
-                DockerTestUtils.removeDockerImage(imageName);
-            }
+            DockerTestUtils.removeDockerImage(imageName);
         }
     }
 

--- a/test/hotspot/jtreg/containers/docker/TestLimitsUpdating.java
+++ b/test/hotspot/jtreg/containers/docker/TestLimitsUpdating.java
@@ -63,9 +63,7 @@ public class TestLimitsUpdating {
         try {
             testLimitUpdates();
         } finally {
-            if (!DockerTestUtils.RETAIN_IMAGE_AFTER_TEST) {
-                DockerTestUtils.removeDockerImage(imageName);
-            }
+            DockerTestUtils.removeDockerImage(imageName);
         }
     }
 

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -102,9 +102,7 @@ public class TestMemoryAwareness {
             testMetricsSwapExceedingPhysical();
             testContainerMemExceedsPhysical();
         } finally {
-            if (!DockerTestUtils.RETAIN_IMAGE_AFTER_TEST) {
-                DockerTestUtils.removeDockerImage(imageName);
-            }
+            DockerTestUtils.removeDockerImage(imageName);
         }
     }
 

--- a/test/hotspot/jtreg/containers/docker/TestPids.java
+++ b/test/hotspot/jtreg/containers/docker/TestPids.java
@@ -63,9 +63,7 @@ public class TestPids {
         try {
             testPids();
         } finally {
-            if (!DockerTestUtils.RETAIN_IMAGE_AFTER_TEST) {
-                DockerTestUtils.removeDockerImage(imageName);
-            }
+            DockerTestUtils.removeDockerImage(imageName);
         }
     }
 

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -81,9 +81,7 @@ public class TestDockerMemoryMetrics {
             testMemorySoftLimit("500m","200m");
 
         } finally {
-            if (!DockerTestUtils.RETAIN_IMAGE_AFTER_TEST) {
-                DockerTestUtils.removeDockerImage(imageName);
-            }
+            DockerTestUtils.removeDockerImage(imageName);
         }
     }
 

--- a/test/jdk/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
+++ b/test/jdk/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
@@ -53,9 +53,7 @@ public class TestGetFreeSwapSpaceSize {
                 "150M", Integer.toString(0)
             );
         } finally {
-            if (!DockerTestUtils.RETAIN_IMAGE_AFTER_TEST) {
-                DockerTestUtils.removeDockerImage(imageName);
-            }
+            DockerTestUtils.removeDockerImage(imageName);
         }
     }
 

--- a/test/jdk/jdk/internal/platform/docker/TestLimitsUpdating.java
+++ b/test/jdk/jdk/internal/platform/docker/TestLimitsUpdating.java
@@ -62,9 +62,7 @@ public class TestLimitsUpdating {
         try {
             testLimitUpdates();
         } finally {
-            if (!DockerTestUtils.RETAIN_IMAGE_AFTER_TEST) {
-                DockerTestUtils.removeDockerImage(imageName);
-            }
+            DockerTestUtils.removeDockerImage(imageName);
         }
     }
 

--- a/test/jdk/jdk/internal/platform/docker/TestPidsLimit.java
+++ b/test/jdk/jdk/internal/platform/docker/TestPidsLimit.java
@@ -59,9 +59,7 @@ public class TestPidsLimit {
             testPidsLimit("2000");
             testPidsLimit("Unlimited");
         } finally {
-            if (!DockerTestUtils.RETAIN_IMAGE_AFTER_TEST) {
-                DockerTestUtils.removeDockerImage(imageName);
-            }
+            DockerTestUtils.removeDockerImage(imageName);
         }
     }
 

--- a/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
@@ -290,7 +290,9 @@ public class DockerTestUtils {
      * @throws Exception
      */
     public static void removeDockerImage(String imageNameAndTag) throws Exception {
+        if(!DockerTestUtils.RETAIN_IMAGE_AFTER_TEST) {
             execute(Container.ENGINE_COMMAND, "rmi", "--force", imageNameAndTag);
+        }
     }
 
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [34f24131](https://github.com/openjdk/jdk/commit/34f241317ecd7473cfb6dcc2e6e5cf3a40299e2c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 15 Dec 2025 and was reviewed by Leonid Mesnik and David Holmes.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8371503](https://bugs.openjdk.org/browse/JDK-8371503) needs maintainer approval

### Issue
 * [JDK-8371503](https://bugs.openjdk.org/browse/JDK-8371503): RETAIN_IMAGE_AFTER_TEST do not work for some tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/52/head:pull/52` \
`$ git checkout pull/52`

Update a local copy of the PR: \
`$ git checkout pull/52` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/52/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 52`

View PR using the GUI difftool: \
`$ git pr show -t 52`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/52.diff">https://git.openjdk.org/jdk26u/pull/52.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/52#issuecomment-3900533806)
</details>
