### PR TITLE
8376684: Compile OpenJDK in headless mode without required X11 libraries

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -1385,10 +1385,9 @@ dpkg-deb -x /tmp/libasound2-dev_1.0.25-4_armhf.deb .</code></pre></li>
 can specify it by <code>--with-alsa</code>.</p></li>
 </ul>
 <h4 id="x11-1">X11</h4>
-<p>You will need X11 libraries suitable for your <em>target</em> system.
-In most cases, using Debian's pre-built libraries work fine.</p>
-<p>Note that X11 is needed even if you only want to build a headless
-JDK.</p>
+<p>When not building a headless JDK, you will need X11 libraries
+suitable for your <em>target</em> system. In most cases, using Debian's
+pre-built libraries work fine.</p>
 <ul>
 <li><p>Go to <a href="https://www.debian.org/distrib/packages">Debian
 Package Search</a>, search for the following packages for your

--- a/doc/building.md
+++ b/doc/building.md
@@ -1178,10 +1178,8 @@ Note that alsa is needed even if you only want to build a headless JDK.
 
 #### X11
 
-You will need X11 libraries suitable for your *target* system. In most cases,
-using Debian's pre-built libraries work fine.
-
-Note that X11 is needed even if you only want to build a headless JDK.
+When not building a headless JDK, you will need X11 libraries suitable for your
+*target* system. In most cases, using Debian's pre-built libraries work fine.
 
 * Go to [Debian Package Search](https://www.debian.org/distrib/packages),
   search for the following packages for your *target* system, and download them

--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -42,12 +42,12 @@ m4_include([lib-tests.m4])
 AC_DEFUN_ONCE([LIB_DETERMINE_DEPENDENCIES],
 [
   # Check if X11 is needed
-  if test "x$OPENJDK_TARGET_OS" = xwindows || test "x$OPENJDK_TARGET_OS" = xmacosx; then
-    # No X11 support on windows or macosx
+  if test "x$OPENJDK_TARGET_OS" = xwindows ||
+     test "x$OPENJDK_TARGET_OS" = xmacosx ||
+     test "x$ENABLE_HEADLESS_ONLY" = xtrue; then
     NEEDS_LIB_X11=false
   else
-    # All other instances need X11, even if building headless only, libawt still
-    # needs X11 headers.
+    # All other instances need X11 for libawt.
     NEEDS_LIB_X11=true
   fi
 

--- a/make/modules/java.desktop/lib/AwtLibraries.gmk
+++ b/make/modules/java.desktop/lib/AwtLibraries.gmk
@@ -88,6 +88,10 @@ LIBAWT_EXTRA_HEADER_DIRS := \
 
 LIBAWT_CFLAGS := -D__MEDIALIB_OLD_NAMES -D__USE_J2D_NAMES -DMLIB_NO_LIBSUNMATH
 
+ifeq ($(ENABLE_HEADLESS_ONLY), true)
+  LIBAWT_CFLAGS += -DHEADLESS
+endif
+
 ifeq ($(call isTargetOs, windows), true)
   LIBAWT_CFLAGS += -EHsc -DUNICODE -D_UNICODE -DMLIB_OS64BIT
   LIBAWT_RCFLAGS ?= -I$(TOPDIR)/src/java.base/windows/native/launcher/icons
@@ -167,11 +171,18 @@ ifeq ($(call isTargetOs, windows macosx), false)
       $(TOPDIR)/src/$(MODULE)/$(OPENJDK_TARGET_OS_TYPE)/native/common/awt \
       #
 
+  LIBAWT_HEADLESS_EXCLUDE_FILES := \
+      GLXGraphicsConfig.c \
+      GLXSurfaceData.c \
+      X11PMBlitLoops.c \
+      X11Renderer.c \
+      X11SurfaceData.c \
+      #
+
   LIBAWT_HEADLESS_EXTRA_HEADER_DIRS := \
       $(LIBAWT_DEFAULT_HEADER_DIRS) \
       common/awt/debug \
       common/font \
-      common/java2d/opengl \
       java.base:libjvm \
       #
 
@@ -191,7 +202,8 @@ ifeq ($(call isTargetOs, windows macosx), false)
   $(eval $(call SetupJdkLibrary, BUILD_LIBAWT_HEADLESS, \
       NAME := awt_headless, \
       EXTRA_SRC := $(LIBAWT_HEADLESS_EXTRA_SRC), \
-      EXCLUDES := medialib, \
+      EXCLUDES := medialib opengl, \
+      EXCLUDE_FILES := $(LIBAWT_HEADLESS_EXCLUDE_FILES), \
       ONLY_EXPORTED := $(LIBAWT_HEADLESS_ONLY_EXPORTED), \
       OPTIMIZATION := LOW, \
       CFLAGS := -DHEADLESS=true $(CUPS_CFLAGS) $(FONTCONFIG_CFLAGS) \

--- a/src/java.desktop/unix/native/common/awt/utility/rect.h
+++ b/src/java.desktop/unix/native/common/awt/utility/rect.h
@@ -28,7 +28,7 @@
 #ifndef _AWT_RECT_H
 #define _AWT_RECT_H
 
-#ifndef MACOSX
+#if !defined(HEADLESS) && !defined(MACOSX)
 #include <X11/Xlib.h>
 typedef XRectangle RECT_T;
 #else
@@ -39,7 +39,7 @@ typedef struct {
     int width;
     int height;
 } RECT_T;
-#endif /* !MACOSX */
+#endif /* !HEADLESS && !MACOSX */
 
 #define RECT_EQ_X(r1,r2)        ((r1).x==(r2).x && (r1).width==(r2).width)
 


### PR DESCRIPTION
As requested in https://github.com/openjdk/jdk25u-dev/pull/242#issuecomment-3883209948, this is a try to get it back-ported to some of the LTS branches. (25, 21 and 17)

Upstream work: https://github.com/openjdk/jdk/commit/1069ccebcc32e02055985e2babfa2986a2e295ca

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8376684](https://bugs.openjdk.org/browse/JDK-8376684) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8376684](https://bugs.openjdk.org/browse/JDK-8376684): Compile OpenJDK in headless mode without required X11 libraries (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/53/head:pull/53` \
`$ git checkout pull/53`

Update a local copy of the PR: \
`$ git checkout pull/53` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/53/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 53`

View PR using the GUI difftool: \
`$ git pr show -t 53`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/53.diff">https://git.openjdk.org/jdk26u/pull/53.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/53#issuecomment-3904207461)
</details>
