### PR TITLE
8377347: jdk/jfr/event/gc/detailed/TestZAllocationStallEvent.java intermittent OOME

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/detailed/TestZAllocationStallEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestZAllocationStallEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,8 @@ import jdk.test.lib.jfr.Events;
  * @requires vm.hasJFR & vm.gc.Z
  * @requires vm.flagless
  * @library /test/lib /test/jdk /test/hotspot/jtreg
- * @run main/othervm -XX:+UseZGC -Xmx32M -Xlog:gc*:gc.log::filecount=0 jdk.jfr.event.gc.detailed.TestZAllocationStallEvent
+ * @run main/othervm -XX:+UseZGC -Xmx64M -Xlog:gc*:gc.log::filecount=0
+ *                   jdk.jfr.event.gc.detailed.TestZAllocationStallEvent
  */
 
 public class TestZAllocationStallEvent {
@@ -47,7 +48,7 @@ public class TestZAllocationStallEvent {
             recording.start();
 
             // Allocate many large objects quickly, to outrun the GC
-            for (int i = 0; i < 100; i++) {
+            for (int i = 0; i < 1000; i++) {
                 blackHole(new byte[4 * 1024 * 1024]);
             }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [0842782b](https://github.com/openjdk/jdk/commit/0842782b7ab9e57028fa527073c8f2523137f612) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 13 Feb 2026 and was reviewed by Albert Mingkun Yang and Stefan Karlsson.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8377347](https://bugs.openjdk.org/browse/JDK-8377347) needs maintainer approval

### Issue
 * [JDK-8377347](https://bugs.openjdk.org/browse/JDK-8377347): jdk/jfr/event/gc/detailed/TestZAllocationStallEvent.java intermittent OOME (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/54/head:pull/54` \
`$ git checkout pull/54`

Update a local copy of the PR: \
`$ git checkout pull/54` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/54/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 54`

View PR using the GUI difftool: \
`$ git pr show -t 54`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/54.diff">https://git.openjdk.org/jdk26u/pull/54.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/54#issuecomment-3904215492)
</details>
