### PR TITLE
8376402: Dependencies::print_statistics() and AbstractClassHierarchyWalker::print_statistics() are not called from PRODUCT code

### DIFF
--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1124,7 +1124,7 @@ class AbstractClassHierarchyWalker {
   Klass* find_witness(InstanceKlass* context_type, KlassDepChange* changes = nullptr);
 
   static void init();
-  static void print_statistics();
+  NOT_PRODUCT(static void print_statistics();)
 };
 
 PerfCounter* AbstractClassHierarchyWalker::_perf_find_witness_anywhere_calls_count = nullptr;
@@ -2277,6 +2277,7 @@ bool KlassDepChange::involves_context(Klass* k) {
   return is_contained;
 }
 
+#ifndef PRODUCT
 void Dependencies::print_statistics() {
   AbstractClassHierarchyWalker::print_statistics();
 }
@@ -2302,6 +2303,7 @@ void AbstractClassHierarchyWalker::print_statistics() {
     }
   }
 }
+#endif
 
 CallSiteDepChange::CallSiteDepChange(Handle call_site, Handle method_handle) :
   _call_site(call_site),

--- a/src/hotspot/share/code/dependencies.hpp
+++ b/src/hotspot/share/code/dependencies.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -649,7 +649,7 @@ class Dependencies: public ResourceObj {
   };
   friend class Dependencies::DepStream;
 
-  static void print_statistics();
+  NOT_PRODUCT(static void print_statistics();)
 };
 
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8376402](https://bugs.openjdk.org/browse/JDK-8376402) needs maintainer approval

### Issue
 * [JDK-8376402](https://bugs.openjdk.org/browse/JDK-8376402): Dependencies::print_statistics() and AbstractClassHierarchyWalker::print_statistics() are not called from PRODUCT code (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/58.diff">https://git.openjdk.org/jdk26u/pull/58.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/58#issuecomment-3921479712)
</details>
