### PR TITLE
8378113: Add sun/java2d/OpenGL/ScaleParamsOOB.java to the ProblemList.txt file

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -249,6 +249,7 @@ sun/awt/shell/ShellFolderMemoryLeak.java 8197794 windows-all
 sun/java2d/DirectX/OverriddenInsetsTest/OverriddenInsetsTest.java 8196102 generic-all
 sun/java2d/DirectX/RenderingToCachedGraphicsTest/RenderingToCachedGraphicsTest.java 8196180 windows-all,macosx-all
 sun/java2d/OpenGL/OpaqueDest.java#id1 8367574 macosx-all
+sun/java2d/OpenGL/ScaleParamsOOB.java#id0 8377908 linux-all
 sun/java2d/SunGraphics2D/EmptyClipRenderingTest.java 8144029 macosx-all,linux-all
 sun/java2d/SunGraphics2D/DrawImageBilinear.java 8297175 linux-all
 sun/java2d/SunGraphics2D/PolyVertTest.java 6986565 generic-all


### PR DESCRIPTION
Backporting JDK-8378113: Add sun/java2d/OpenGL/ScaleParamsOOB.java to the ProblemList.txt file.

This PR adds the sun/java2d/OpenGL/ScaleParamsOOB.java test to the ProblemList.txt file due to failures on Linux after JDK-8358058.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8378113](https://bugs.openjdk.org/browse/JDK-8378113) needs maintainer approval

### Issue
 * [JDK-8378113](https://bugs.openjdk.org/browse/JDK-8378113): Add sun/java2d/OpenGL/ScaleParamsOOB.java to the ProblemList.txt file (**Task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/60/head:pull/60` \
`$ git checkout pull/60`

Update a local copy of the PR: \
`$ git checkout pull/60` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/60/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 60`

View PR using the GUI difftool: \
`$ git pr show -t 60`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/60.diff">https://git.openjdk.org/jdk26u/pull/60.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/60#issuecomment-3921823009)
</details>
