### PR TITLE
8376688: Gtest os.attempt_reserve_memory_between_small_range_fill_hole_vm fails on AIX 7.3

### DIFF
--- a/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
+++ b/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
@@ -335,6 +335,8 @@ TEST_VM(os, attempt_reserve_memory_randomization_cornercases) {
 
 // Test that, regardless where the hole is in the [min, max) range, if we probe nonrandomly, we will fill that hole
 // as long as the range size is smaller than the number of probe attempts
+// On AIX, the allocation granularity is too large and not well suited for 'small' holes, so we avoid the test
+#if !defined(_AIX)
 TEST_VM(os, attempt_reserve_memory_between_small_range_fill_hole) {
   const size_t ps = os::vm_page_size();
   const size_t ag = allocation_granularity();
@@ -348,3 +350,4 @@ TEST_VM(os, attempt_reserve_memory_between_small_range_fill_hole) {
     }
   }
 }
+#endif


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8376688](https://bugs.openjdk.org/browse/JDK-8376688) needs maintainer approval

### Issue
 * [JDK-8376688](https://bugs.openjdk.org/browse/JDK-8376688): Gtest os.attempt_reserve_memory_between_small_range_fill_hole_vm fails on AIX 7.3 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/63/head:pull/63` \
`$ git checkout pull/63`

Update a local copy of the PR: \
`$ git checkout pull/63` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/63/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 63`

View PR using the GUI difftool: \
`$ git pr show -t 63`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/63.diff">https://git.openjdk.org/jdk26u/pull/63.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/63#issuecomment-3928559084)
</details>
