### PR TITLE
8373869: Refactor java/net/httpclient/ThrowingPushPromises*.java tests to use JUnit5

### DIFF
--- a/test/jdk/java/net/httpclient/ThrowingPushPromisesAsInputStreamCustom.java
+++ b/test/jdk/java/net/httpclient/ThrowingPushPromisesAsInputStreamCustom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,14 +30,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *       ReferenceTracker AbstractThrowingPushPromises ThrowingPushPromisesAsInputStreamCustom
  *       jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingPushPromisesAsInputStreamCustom
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingPushPromisesAsInputStreamCustom
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingPushPromisesAsInputStreamCustom extends AbstractThrowingPushPromises {
 
-    @Test(dataProvider = "customVariants")
+    @ParameterizedTest
+    @MethodSource("customVariants")
     public void testThrowingAsInputStream(String uri, boolean sameClient, Thrower thrower)
             throws Exception {
         super.testThrowingAsInputStreamImpl(uri, sameClient, thrower);

--- a/test/jdk/java/net/httpclient/ThrowingPushPromisesAsInputStreamIO.java
+++ b/test/jdk/java/net/httpclient/ThrowingPushPromisesAsInputStreamIO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,14 +30,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker AbstractThrowingPushPromises ThrowingPushPromisesAsInputStreamIO
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingPushPromisesAsInputStreamIO
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingPushPromisesAsInputStreamIO
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingPushPromisesAsInputStreamIO extends AbstractThrowingPushPromises {
 
-    @Test(dataProvider = "ioVariants")
+    @ParameterizedTest
+    @MethodSource("ioVariants")
     public void testThrowingAsInputStream(String uri, boolean sameClient, Thrower thrower)
             throws Exception {
         super.testThrowingAsInputStreamImpl(uri, sameClient, thrower);

--- a/test/jdk/java/net/httpclient/ThrowingPushPromisesAsLinesCustom.java
+++ b/test/jdk/java/net/httpclient/ThrowingPushPromisesAsLinesCustom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,14 +30,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker AbstractThrowingPushPromises ThrowingPushPromisesAsLinesCustom
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingPushPromisesAsLinesCustom
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingPushPromisesAsLinesCustom
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingPushPromisesAsLinesCustom extends AbstractThrowingPushPromises {
 
-    @Test(dataProvider = "customVariants")
+    @ParameterizedTest
+    @MethodSource("customVariants")
     public void testThrowingAsLines(String uri, boolean sameClient, Thrower thrower)
             throws Exception {
         super.testThrowingAsLinesImpl(uri, sameClient, thrower);

--- a/test/jdk/java/net/httpclient/ThrowingPushPromisesAsLinesIO.java
+++ b/test/jdk/java/net/httpclient/ThrowingPushPromisesAsLinesIO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,14 +30,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker AbstractThrowingPushPromises ThrowingPushPromisesAsLinesIO
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingPushPromisesAsLinesIO
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingPushPromisesAsLinesIO
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingPushPromisesAsLinesIO extends AbstractThrowingPushPromises {
 
-    @Test(dataProvider = "ioVariants")
+    @ParameterizedTest
+    @MethodSource("ioVariants")
     public void testThrowingAsLines(String uri, boolean sameClient, Thrower thrower)
             throws Exception {
         super.testThrowingAsLinesImpl(uri, sameClient, thrower);

--- a/test/jdk/java/net/httpclient/ThrowingPushPromisesAsStringCustom.java
+++ b/test/jdk/java/net/httpclient/ThrowingPushPromisesAsStringCustom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,14 +30,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker AbstractThrowingPushPromises ThrowingPushPromisesAsStringCustom
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingPushPromisesAsStringCustom
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingPushPromisesAsStringCustom
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingPushPromisesAsStringCustom extends AbstractThrowingPushPromises {
 
-    @Test(dataProvider = "customVariants")
+    @ParameterizedTest
+    @MethodSource("customVariants")
     public void testThrowingAsString(String uri, boolean sameClient, Thrower thrower)
             throws Exception {
         super.testThrowingAsStringImpl(uri, sameClient, thrower);

--- a/test/jdk/java/net/httpclient/ThrowingPushPromisesAsStringIO.java
+++ b/test/jdk/java/net/httpclient/ThrowingPushPromisesAsStringIO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,14 +30,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker AbstractThrowingPushPromises ThrowingPushPromisesAsStringIO
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingPushPromisesAsStringIO
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingPushPromisesAsStringIO
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingPushPromisesAsStringIO extends AbstractThrowingPushPromises {
 
-    @Test(dataProvider = "ioVariants")
+    @ParameterizedTest
+    @MethodSource("ioVariants")
     public void testThrowingAsString(String uri, boolean sameClient, Thrower thrower)
             throws Exception {
         super.testThrowingAsStringImpl(uri, sameClient, thrower);

--- a/test/jdk/java/net/httpclient/ThrowingPushPromisesSanity.java
+++ b/test/jdk/java/net/httpclient/ThrowingPushPromisesSanity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,14 +30,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker AbstractThrowingPushPromises ThrowingPushPromisesSanity
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingPushPromisesSanity
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingPushPromisesSanity
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingPushPromisesSanity extends AbstractThrowingPushPromises {
 
-    @Test(dataProvider = "sanity")
+    @ParameterizedTest
+    @MethodSource("sanity")
     public void testSanity(String uri, boolean sameClient)
             throws Exception {
         super.testSanityImpl(uri, sameClient);


### PR DESCRIPTION
Tested local changes and no failure is observed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8373869](https://bugs.openjdk.org/browse/JDK-8373869) needs maintainer approval

### Issue
 * [JDK-8373869](https://bugs.openjdk.org/browse/JDK-8373869): Refactor java/net/httpclient/ThrowingPushPromises*.java tests to use JUnit5 (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/65/head:pull/65` \
`$ git checkout pull/65`

Update a local copy of the PR: \
`$ git checkout pull/65` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/65/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 65`

View PR using the GUI difftool: \
`$ git pr show -t 65`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/65.diff">https://git.openjdk.org/jdk26u/pull/65.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/65#issuecomment-3931975331)
</details>
