### PR TITLE
8377949: TestZRelocationSetEvent.java intermittent fails OOME

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/detailed/TestZRelocationSetEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestZRelocationSetEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@ package jdk.jfr.event.gc.detailed;
 
 import java.util.List;
 
-import static gc.testlibrary.Allocation.blackHole;
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.test.lib.jfr.EventNames;
@@ -36,7 +35,7 @@ import jdk.test.lib.jfr.Events;
  * @requires vm.hasJFR & vm.gc.Z
  * @requires vm.flagless
  * @library /test/lib /test/jdk /test/hotspot/jtreg
- * @run main/othervm -XX:+UseZGC -Xmx32M jdk.jfr.event.gc.detailed.TestZRelocationSetEvent
+ * @run main/othervm -XX:+UseZGC -Xmx64M jdk.jfr.event.gc.detailed.TestZRelocationSetEvent
  */
 
 public class TestZRelocationSetEvent {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [cb706549](https://github.com/openjdk/jdk/commit/cb70654943695049e75743ee957c7c51ac33ffdc) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 20 Feb 2026 and was reviewed by Stefan Karlsson and Markus Grönlund.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8377949](https://bugs.openjdk.org/browse/JDK-8377949) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8377949](https://bugs.openjdk.org/browse/JDK-8377949): TestZRelocationSetEvent.java intermittent fails OOME (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/66/head:pull/66` \
`$ git checkout pull/66`

Update a local copy of the PR: \
`$ git checkout pull/66` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/66/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 66`

View PR using the GUI difftool: \
`$ git pr show -t 66`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/66.diff">https://git.openjdk.org/jdk26u/pull/66.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/66#issuecomment-3932427688)
</details>
