### PR TITLE
8378353: [PPC64] StringCoding.countPositives causes errors when the length is not a proper 32 bit int

### DIFF
--- a/src/hotspot/cpu/ppc/c2_MacroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c2_MacroAssembler_ppc.cpp
@@ -600,19 +600,21 @@ void C2_MacroAssembler::count_positives(Register src, Register cnt, Register res
   orr(tmp0, tmp2, tmp0);
 
   and_(tmp0, tmp0, tmp1);
-  bne(CR0, Lslow);               // Found negative byte.
+  bne(CR0, Lslow);                // Found negative byte.
   addi(result, result, 16);
   bdnz(Lfastloop);
 
   bind(Lslow);                    // Fallback to slow version.
   subf(tmp0, src, result);        // Bytes known positive.
-  subf_(tmp0, tmp0, cnt);         // Remaining Bytes.
+  clrldi(tmp1, cnt, 32);          // Clear garbage from upper 32 bits.
+  subf_(tmp0, tmp0, tmp1);        // Remaining Bytes.
   beq(CR0, Ldone);
   mtctr(tmp0);
+
   bind(Lloop);
   lbz(tmp0, 0, result);
   andi_(tmp0, tmp0, 0x80);
-  bne(CR0, Ldone);               // Found negative byte.
+  bne(CR0, Ldone);                // Found negative byte.
   addi(result, result, 1);
   bdnz(Lloop);
 


### PR DESCRIPTION
Clean backport of [JDK-8378353](https://bugs.openjdk.org/browse/JDK-8378353).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8378353](https://bugs.openjdk.org/browse/JDK-8378353) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8378353](https://bugs.openjdk.org/browse/JDK-8378353): [PPC64] StringCoding.countPositives causes errors when the length is not a proper 32 bit int (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/68.diff">https://git.openjdk.org/jdk26u/pull/68.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/68#issuecomment-3944891581)
</details>
