### PR TITLE
8373537: Migrate "test/jdk/com/sun/net/httpserver/" to null-safe "SimpleSSLContext" methods

### DIFF
--- a/test/jdk/com/sun/net/httpserver/HttpsParametersClientAuthTest.java
+++ b/test/jdk/com/sun/net/httpserver/HttpsParametersClientAuthTest.java
@@ -84,6 +84,7 @@ public class HttpsParametersClientAuthTest {
         return t;
     };
 
+    private static final SSLContext serverSSLCtx = SimpleSSLContext.findSSLContext();
     /**
      * verifies default values of {@link HttpsParameters#setNeedClientAuth(boolean)}
      * and {@link HttpsParameters#setWantClientAuth(boolean)} methods
@@ -168,8 +169,6 @@ public class HttpsParametersClientAuthTest {
     public void testServerNeedClientAuth(final boolean presentClientCerts) throws Exception {
         // SSLContext which contains both the key and the trust material and will be used
         // by the server
-        final SSLContext serverSSLCtx = new SimpleSSLContext().get();
-        assertNotNull(serverSSLCtx, "could not create SSLContext");
         final HttpsConfigurator configurator = new HttpsConfigurator(serverSSLCtx) {
             @Override
             public void configure(final HttpsParameters params) {
@@ -276,8 +275,6 @@ public class HttpsParametersClientAuthTest {
     public void testServerWantClientAuth(final boolean presentClientCerts) throws Exception {
         // SSLContext which contains both the key and the trust material and will be used
         // by the server
-        final SSLContext serverSSLCtx = new SimpleSSLContext().get();
-        assertNotNull(serverSSLCtx, "could not create SSLContext");
         final HttpsConfigurator configurator = new HttpsConfigurator(serverSSLCtx) {
             @Override
             public void configure(final HttpsParameters params) {

--- a/test/jdk/com/sun/net/httpserver/SANTest.java
+++ b/test/jdk/com/sun/net/httpserver/SANTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,7 @@ import jdk.httpclient.test.lib.http2.Http2TestServer;
  */
 public class SANTest implements HttpServerAdapters {
 
-    static SSLContext ctx;
+    private static final SSLContext ctx = SimpleSSLContext.findSSLContext();
 
     static HttpServer getHttpsServer(InetSocketAddress addr, Executor exec, SSLContext ctx) throws Exception {
         HttpsServer server = HttpsServer.create(addr, 0);
@@ -122,7 +122,6 @@ public class SANTest implements HttpServerAdapters {
         ExecutorService executor=null;
         try {
             System.out.print ("SANTest: ");
-            ctx = new SimpleSSLContext().get();
             executor = Executors.newCachedThreadPool();
 
             InetAddress l1 = InetAddress.getByName("::1");

--- a/test/jdk/com/sun/net/httpserver/SelCacheTest.java
+++ b/test/jdk/com/sun/net/httpserver/SelCacheTest.java
@@ -59,7 +59,7 @@ public class SelCacheTest extends Test {
     private static final String TEMP_FILE_PREFIX =
             HttpServer.class.getPackageName() + '-' + SelCacheTest.class.getSimpleName() + '-';
 
-    static SSLContext ctx;
+    private static final SSLContext ctx = SimpleSSLContext.findSSLContext();
 
     public static void main(String[] args) throws Exception {
         HttpServer s1 = null;
@@ -84,7 +84,6 @@ public class SelCacheTest extends Test {
             executor = Executors.newCachedThreadPool();
             s1.setExecutor(executor);
             s2.setExecutor(executor);
-            ctx = new SimpleSSLContext().get();
             s2.setHttpsConfigurator(new HttpsConfigurator(ctx));
             s1.start();
             s2.start();

--- a/test/jdk/com/sun/net/httpserver/Test1.java
+++ b/test/jdk/com/sun/net/httpserver/Test1.java
@@ -69,7 +69,7 @@ public class Test1 extends Test {
     private static final String TEMP_FILE_PREFIX =
             HttpServer.class.getPackageName() + '-' + Test1.class.getSimpleName() + '-';
 
-    static SSLContext ctx;
+    private static final SSLContext ctx = SimpleSSLContext.findSSLContext();
 
     public static void main (String[] args) throws Exception {
         HttpServer s1 = null;
@@ -94,7 +94,6 @@ public class Test1 extends Test {
             executor = Executors.newCachedThreadPool();
             s1.setExecutor (executor);
             s2.setExecutor (executor);
-            ctx = new SimpleSSLContext().get();
             s2.setHttpsConfigurator(new HttpsConfigurator (ctx));
             s1.start();
             s2.start();

--- a/test/jdk/com/sun/net/httpserver/Test12.java
+++ b/test/jdk/com/sun/net/httpserver/Test12.java
@@ -56,7 +56,7 @@ public class Test12 extends Test {
     private static final String TEMP_FILE_PREFIX =
             HttpServer.class.getPackageName() + '-' + Test12.class.getSimpleName() + '-';
 
-    static SSLContext ctx;
+    private static final SSLContext ctx = SimpleSSLContext.findSSLContext();
 
     public static void main (String[] args) throws Exception {
         HttpServer s1 = null;
@@ -77,7 +77,6 @@ public class Test12 extends Test {
             HttpContext c2 = s2.createContext ("/", h);
             s1.setExecutor (executor);
             s2.setExecutor (executor);
-            ctx = new SimpleSSLContext().get();
             s2.setHttpsConfigurator(new HttpsConfigurator (ctx));
             s1.start();
             s2.start();

--- a/test/jdk/com/sun/net/httpserver/Test13.java
+++ b/test/jdk/com/sun/net/httpserver/Test13.java
@@ -59,7 +59,7 @@ public class Test13 extends Test {
     private static final String TEMP_FILE_PREFIX =
             HttpServer.class.getPackageName() + '-' + Test13.class.getSimpleName() + '-';
 
-    static SSLContext ctx;
+    private static final SSLContext ctx = SimpleSSLContext.findSSLContext();
 
     final static int NUM = 32; // was 32
 
@@ -87,7 +87,6 @@ public class Test13 extends Test {
             executor = Executors.newCachedThreadPool();
             s1.setExecutor (executor);
             s2.setExecutor (executor);
-            ctx = new SimpleSSLContext().get();
             s2.setHttpsConfigurator(new HttpsConfigurator (ctx));
             s1.start();
             s2.start();

--- a/test/jdk/com/sun/net/httpserver/Test6a.java
+++ b/test/jdk/com/sun/net/httpserver/Test6a.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 6270015
  * @library /test/lib
@@ -55,7 +55,7 @@ public class Test6a extends Test {
         HttpsServer server = HttpsServer.create (addr, 0);
         HttpContext ctx = server.createContext ("/test", handler);
         ExecutorService executor = Executors.newCachedThreadPool();
-        SSLContext ssl = new SimpleSSLContext().get();
+        SSLContext ssl = SimpleSSLContext.findSSLContext();
         server.setExecutor (executor);
         server.setHttpsConfigurator(new HttpsConfigurator (ssl));
         server.start ();

--- a/test/jdk/com/sun/net/httpserver/Test7a.java
+++ b/test/jdk/com/sun/net/httpserver/Test7a.java
@@ -59,7 +59,7 @@ public class Test7a extends Test {
         HttpsServer server = HttpsServer.create (addr, 0);
         HttpContext ctx = server.createContext ("/test", handler);
         ExecutorService executor = Executors.newCachedThreadPool();
-        SSLContext ssl = new SimpleSSLContext().get();
+        SSLContext ssl = SimpleSSLContext.findSSLContext();
         server.setHttpsConfigurator(new HttpsConfigurator (ssl));
         server.setExecutor (executor);
         server.start ();

--- a/test/jdk/com/sun/net/httpserver/Test8a.java
+++ b/test/jdk/com/sun/net/httpserver/Test8a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ public class Test8a extends Test {
             server = HttpsServer.create (addr, 0);
             HttpContext ctx = server.createContext ("/test", handler);
             executor = Executors.newCachedThreadPool();
-            SSLContext ssl = new SimpleSSLContext().get();
+            SSLContext ssl = SimpleSSLContext.findSSLContext();
             server.setHttpsConfigurator(new HttpsConfigurator (ssl));
             server.setExecutor (executor);
             server.start ();

--- a/test/jdk/com/sun/net/httpserver/Test9.java
+++ b/test/jdk/com/sun/net/httpserver/Test9.java
@@ -58,7 +58,7 @@ public class Test9 extends Test {
     private static final String TEMP_FILE_PREFIX =
             HttpServer.class.getPackageName() + '-' + Test9.class.getSimpleName() + '-';
 
-    static SSLContext ctx;
+    private static final SSLContext ctx = SimpleSSLContext.findSSLContext();
     static volatile boolean error = false;
 
     public static void main (String[] args) throws Exception {
@@ -83,7 +83,6 @@ public class Test9 extends Test {
             executor = Executors.newCachedThreadPool();
             s1.setExecutor (executor);
             s2.setExecutor (executor);
-            ctx = new SimpleSSLContext().get();
             s2.setHttpsConfigurator(new HttpsConfigurator (ctx));
             s1.start();
             s2.start();

--- a/test/jdk/com/sun/net/httpserver/Test9a.java
+++ b/test/jdk/com/sun/net/httpserver/Test9a.java
@@ -56,8 +56,8 @@ public class Test9a extends Test {
     private static final String TEMP_FILE_PREFIX =
             HttpServer.class.getPackageName() + '-' + Test9a.class.getSimpleName() + '-';
 
-    static SSLContext serverCtx;
-    static volatile SSLContext clientCtx = null;
+    private static final SSLContext serverCtx = SimpleSSLContext.findSSLContext();
+    private static final SSLContext clientCtx = SimpleSSLContext.findSSLContext();
     static volatile boolean error = false;
 
     public static void main (String[] args) throws Exception {
@@ -76,8 +76,6 @@ public class Test9a extends Test {
             HttpContext c1 = server.createContext ("/", h);
             executor = Executors.newCachedThreadPool();
             server.setExecutor (executor);
-            serverCtx = new SimpleSSLContext().get();
-            clientCtx = new SimpleSSLContext().get();
             server.setHttpsConfigurator(new HttpsConfigurator (serverCtx));
             server.start();
 

--- a/test/jdk/com/sun/net/httpserver/bugs/HandlerConnectionClose.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/HandlerConnectionClose.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class HandlerConnectionClose
 {
     static final int ONEK = 1024;
     static final long POST_SIZE = ONEK * 1L;
-    SSLContext sslContext;
+    private static final SSLContext sslContext = SimpleSSLContext.findSSLContext();
     Logger logger;
 
     void test(String[] args) throws Exception {
@@ -77,7 +77,6 @@ public class HandlerConnectionClose
         } finally {
             httpServer.stop(0);
         }
-        sslContext = new SimpleSSLContext().get();
         HttpServer httpsServer = startHttpServer("https");
         try {
             testHttpURLConnection(httpsServer, "https","/close/legacy/https/chunked");

--- a/test/jdk/com/sun/net/httpserver/simpleserver/HttpsServerAlertTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/HttpsServerAlertTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,11 @@ public class HttpsServerAlertTest {
     static final boolean ENABLE_LOGGING = true;
     static final Logger LOGGER = Logger.getLogger("com.sun.net.httpserver");
 
-    SSLContext sslContext;
+    private static final SSLContext sslContext = SimpleSSLContext.findSSLContext();
+
+    static {
+        SSLContext.setDefault(sslContext);
+    }
 
     @BeforeTest
     public void setup() throws IOException {
@@ -69,8 +73,6 @@ public class HttpsServerAlertTest {
             ch.setLevel(Level.ALL);
             LOGGER.addHandler(ch);
         }
-        sslContext = new SimpleSSLContext().get();
-        SSLContext.setDefault(sslContext);
     }
 
     @Test

--- a/test/jdk/com/sun/net/httpserver/simpleserver/HttpsServerTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/HttpsServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -67,7 +66,11 @@ public class HttpsServerTest {
     static final boolean ENABLE_LOGGING = true;
     static final Logger LOGGER = Logger.getLogger("com.sun.net.httpserver");
 
-    SSLContext sslContext;
+    private static final SSLContext sslContext = SimpleSSLContext.findSSLContext();
+
+    static {
+        SSLContext.setDefault(sslContext);
+    }
 
     @BeforeTest
     public void setup() throws IOException {
@@ -77,8 +80,6 @@ public class HttpsServerTest {
             ch.setLevel(Level.ALL);
             LOGGER.addHandler(ch);
         }
-        sslContext = new SimpleSSLContext().get();
-        SSLContext.setDefault(sslContext);
     }
 
     @Test

--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/MaxRequestTimeTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/MaxRequestTimeTest.java
@@ -78,7 +78,7 @@ public class MaxRequestTimeTest {
     static final String LOOPBACK_ADDR = InetAddress.getLoopbackAddress().getHostAddress();
     static final AtomicInteger PORT = new AtomicInteger();
 
-    static SSLContext sslContext;
+    private static final SSLContext sslContext = SimpleSSLContext.findSSLContext();
 
     @BeforeTest
     public void setup() throws IOException {
@@ -86,10 +86,6 @@ public class MaxRequestTimeTest {
             FileUtils.deleteFileTreeWithRetry(TEST_DIR);
         }
         Files.createDirectories(TEST_DIR);
-
-        sslContext = new SimpleSSLContext().get();
-        if (sslContext == null)
-            throw new AssertionError("Unexpected null sslContext");
     }
 
     @Test


### PR DESCRIPTION
Clean backport, All test passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8373537](https://bugs.openjdk.org/browse/JDK-8373537) needs maintainer approval

### Issue
 * [JDK-8373537](https://bugs.openjdk.org/browse/JDK-8373537): Migrate "test/jdk/com/sun/net/httpserver/" to null-safe "SimpleSSLContext" methods (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/69/head:pull/69` \
`$ git checkout pull/69`

Update a local copy of the PR: \
`$ git checkout pull/69` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/69/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 69`

View PR using the GUI difftool: \
`$ git pr show -t 69`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/69.diff">https://git.openjdk.org/jdk26u/pull/69.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/69#issuecomment-3945428670)
</details>
