### PR TITLE
8377905: gcc.md included with every build

### DIFF
--- a/make/modules/java.base/Copy.gmk
+++ b/make/modules/java.base/Copy.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -170,6 +170,10 @@ TARGETS += $(COPY_JDK_NOTICES)
 #
 ifeq ($(USE_EXTERNAL_LIBZ), true)
   LEGAL_EXCLUDES += zlib.md
+endif
+
+ifneq ($(TOOLCHAIN_TYPE), gcc)
+  LEGAL_EXCLUDES += gcc.md
 endif
 
 $(eval $(call SetupCopyLegalFiles, COPY_LEGAL, \


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [c0c1775a](https://github.com/openjdk/jdk/commit/c0c1775a2b002e82347bb0a0b1167cfe45e7006e) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Mikael Vidstedt on 24 Feb 2026 and was reviewed by Erik Joelsson, Johan Sjölen, Phil Race and David Holmes.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8377905](https://bugs.openjdk.org/browse/JDK-8377905) needs maintainer approval

### Issue
 * [JDK-8377905](https://bugs.openjdk.org/browse/JDK-8377905): gcc.md included with every build (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/72/head:pull/72` \
`$ git checkout pull/72`

Update a local copy of the PR: \
`$ git checkout pull/72` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/72/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 72`

View PR using the GUI difftool: \
`$ git pr show -t 72`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/72.diff">https://git.openjdk.org/jdk26u/pull/72.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/72#issuecomment-3955532082)
</details>
