### PR TITLE
8170896: TEST_BUG: java/rmi/server/Unreferenced/leaseCheckInterval/LeaseCheckInterval.java failed with unreferenced() not invoked after 20.0 seconds

### DIFF
--- a/test/jdk/java/rmi/server/Unreferenced/leaseCheckInterval/SelfTerminator.java
+++ b/test/jdk/java/rmi/server/Unreferenced/leaseCheckInterval/SelfTerminator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,26 +21,32 @@
  * questions.
  */
 
-/*
- *
- */
-
 import java.rmi.Remote;
 import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
+import java.time.Instant;
 
 public class SelfTerminator {
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         try {
+            log("main() invoked");
             int registryPort =
                 Integer.parseInt(System.getProperty("rmi.registry.port"));
             Registry registry =
                 LocateRegistry.getRegistry("", registryPort);
             Remote stub = registry.lookup(LeaseCheckInterval.BINDING);
+            log("looked up binding, now terminating the process");
             Runtime.getRuntime().halt(0);
-        } catch (Exception e) {
-            e.printStackTrace();
+        } catch (Throwable t) {
+            log("failure: " + t);
+            t.printStackTrace();
+            throw t; // propagate any failures and fail the process
         }
+    }
+
+    private static void log(final String message) {
+        final Instant now = Instant.now();
+        System.err.println("[" + now + "] " + SelfTerminator.class.getName() + " - " + message);
     }
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8170896](https://bugs.openjdk.org/browse/JDK-8170896) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8170896](https://bugs.openjdk.org/browse/JDK-8170896): TEST_BUG: java/rmi/server/Unreferenced/leaseCheckInterval/LeaseCheckInterval.java failed with unreferenced() not invoked after 20.0 seconds (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/73/head:pull/73` \
`$ git checkout pull/73`

Update a local copy of the PR: \
`$ git checkout pull/73` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/73/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 73`

View PR using the GUI difftool: \
`$ git pr show -t 73`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/73.diff">https://git.openjdk.org/jdk26u/pull/73.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/73#issuecomment-3956405253)
</details>
