### PR TITLE
8378218: MSYS2 reports cygwin triplet causing bash configure failure

### DIFF
--- a/make/autoconf/platform.m4
+++ b/make/autoconf/platform.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/autoconf/platform.m4
+++ b/make/autoconf/platform.m4
@@ -311,6 +311,12 @@ AC_DEFUN([PLATFORM_EXTRACT_TARGET_AND_BUILD],
   else
     OPENJDK_BUILD_OS_ENV="$VAR_OS"
   fi
+  # Special handling for MSYS2 that reports a Cygwin triplet as the default host triplet.
+  case `uname` in
+    MSYS*)
+      OPENJDK_BUILD_OS_ENV=windows.msys2
+      ;;
+  esac
   OPENJDK_BUILD_CPU="$VAR_CPU"
   OPENJDK_BUILD_CPU_ARCH="$VAR_CPU_ARCH"
   OPENJDK_BUILD_CPU_BITS="$VAR_CPU_BITS"


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [feecb042](https://github.com/openjdk/jdk/commit/feecb042fe4abbb9bb3aa9324de4e40393e03ae1) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Daishi Tabata on 20 Feb 2026 and was reviewed by Erik Joelsson.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8378218](https://bugs.openjdk.org/browse/JDK-8378218) needs maintainer approval

### Issue
 * [JDK-8378218](https://bugs.openjdk.org/browse/JDK-8378218): MSYS2 reports cygwin triplet causing bash configure failure (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/74/head:pull/74` \
`$ git checkout pull/74`

Update a local copy of the PR: \
`$ git checkout pull/74` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/74/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 74`

View PR using the GUI difftool: \
`$ git pr show -t 74`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/74.diff">https://git.openjdk.org/jdk26u/pull/74.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/74#issuecomment-3957815962)
</details>
