### PR TITLE
8370502: C2: segfault while adding node to IGVN worklist

### DIFF
--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2321,12 +2321,7 @@ void PhaseMacroExpand::expand_unlock_node(UnlockNode *unlock) {
   // No need for a null check on unlock
 
   // Make the merge point
-  Node *region;
-  Node *mem_phi;
-
-  region  = new RegionNode(3);
-  // create a Phi for the memory state
-  mem_phi = new PhiNode( region, Type::MEMORY, TypeRawPtr::BOTTOM);
+  Node* region = new RegionNode(3);
 
   FastUnlockNode *funlock = new FastUnlockNode( ctrl, obj, box );
   funlock = transform_later( funlock )->as_FastUnlock();
@@ -2355,12 +2350,15 @@ void PhaseMacroExpand::expand_unlock_node(UnlockNode *unlock) {
   transform_later(region);
   _igvn.replace_node(_callprojs.fallthrough_proj, region);
 
-  Node *memproj = transform_later(new ProjNode(call, TypeFunc::Memory) );
-  mem_phi->init_req(1, memproj );
-  mem_phi->init_req(2, mem);
-  transform_later(mem_phi);
-
-  _igvn.replace_node(_callprojs.fallthrough_memproj, mem_phi);
+  if (_callprojs.fallthrough_memproj != nullptr) {
+    // create a Phi for the memory state
+    Node* mem_phi = new PhiNode( region, Type::MEMORY, TypeRawPtr::BOTTOM);
+    Node* memproj = transform_later(new ProjNode(call, TypeFunc::Memory));
+    mem_phi->init_req(1, memproj);
+    mem_phi->init_req(2, mem);
+    transform_later(mem_phi);
+    _igvn.replace_node(_callprojs.fallthrough_memproj, mem_phi);
+  }
 }
 
 void PhaseMacroExpand::expand_subtypecheck_node(SubTypeCheckNode *check) {

--- a/test/hotspot/jtreg/compiler/c2/TestUnlockNodeNullMemprof.java
+++ b/test/hotspot/jtreg/compiler/c2/TestUnlockNodeNullMemprof.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8370502
+ * @summary Do not segfault while adding node to IGVN worklist
+ *
+ * @run main/othervm -Xbatch ${test.main.class}
+ */
+
+package compiler.c2;
+
+public class TestUnlockNodeNullMemprof {
+    public static void main(String[] args) {
+        int[] a = new int[0]; // test only valid when size is 0.
+        for (int i = 0; i < Integer.valueOf(10000); i++) // test only valid with boxed loop limit
+            try {
+                test(a);
+            } catch (ArrayIndexOutOfBoundsException e) {
+            }
+    }
+
+    static void test(int[] a) {
+        for (int i = 0; i < 1;) {
+            a[i] = 0;
+            synchronized (TestUnlockNodeNullMemprof.class) {
+            }
+            for (int j = 0; Integer.valueOf(j) < 1;)
+                j = 0;
+        }
+    }
+}


### PR DESCRIPTION
Backporting JDK-8370502: C2: segfault while adding node to IGVN worklist.

This PR backports a fix for a C2 segmentation fault that occurs when expanding an UnlockNode with a null memory projection. The fix adds a necessary null check to ensure fallthrough_memproj is valid before attempting to replace it in the IGVN worklist.

make run-test TEST=tier1
make run-test TEST=hotspot_compiler
make run-test TEST=test/hotspot/jtreg/compiler/c2/TestUnlockNodeNullMemprof.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8370502](https://bugs.openjdk.org/browse/JDK-8370502) needs maintainer approval

### Issue
 * [JDK-8370502](https://bugs.openjdk.org/browse/JDK-8370502): C2: segfault while adding node to IGVN worklist (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/75/head:pull/75` \
`$ git checkout pull/75`

Update a local copy of the PR: \
`$ git checkout pull/75` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/75/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 75`

View PR using the GUI difftool: \
`$ git pr show -t 75`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/75.diff">https://git.openjdk.org/jdk26u/pull/75.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/75#issuecomment-3960071320)
</details>
