### PR TITLE
8373718: jdk/internal/misc/VM/RuntimeArguments.java test fails in Virtual threads mode

### DIFF
--- a/test/jdk/jdk/internal/misc/VM/RuntimeArguments.java
+++ b/test/jdk/jdk/internal/misc/VM/RuntimeArguments.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @requires vm.flagless
+ * @requires test.thread.factory == null
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          jdk.zipfs


### PR DESCRIPTION
26u backport of [4d0ad0a4a391286c683ebb8c8d711ea0be68c31a](https://github.com/openjdk/jdk/commit/4d0ad0a4a391286c683ebb8c8d711ea0be68c31a)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8373718](https://bugs.openjdk.org/browse/JDK-8373718) needs maintainer approval

### Issue
 * [JDK-8373718](https://bugs.openjdk.org/browse/JDK-8373718): jdk/internal/misc/VM/RuntimeArguments.java test fails in Virtual threads mode (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/78/head:pull/78` \
`$ git checkout pull/78`

Update a local copy of the PR: \
`$ git checkout pull/78` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/78/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 78`

View PR using the GUI difftool: \
`$ git pr show -t 78`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/78.diff">https://git.openjdk.org/jdk26u/pull/78.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/78#issuecomment-3967529344)
</details>
