### PR TITLE
8378561: Mark gc/shenandoah/compiler/TestLinkToNativeRBP.java as /native

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestLinkToNativeRBP.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestLinkToNativeRBP.java
@@ -30,7 +30,7 @@
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "ppc64" | os.arch == "ppc64le"
  * @requires vm.gc.Shenandoah
  *
- * @run main/othervm --enable-native-access=ALL-UNNAMED -XX:+UnlockDiagnosticVMOptions
+ * @run main/native/othervm --enable-native-access=ALL-UNNAMED -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive TestLinkToNativeRBP
  *
  */


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [d7f4365b](https://github.com/openjdk/jdk/commit/d7f4365b296d120521e16666e2ce2177a8d2c44d) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 27 Feb 2026 and was reviewed by Aleksey Shipilev and William Kemper.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8378561](https://bugs.openjdk.org/browse/JDK-8378561) needs maintainer approval

### Issue
 * [JDK-8378561](https://bugs.openjdk.org/browse/JDK-8378561): Mark gc/shenandoah/compiler/TestLinkToNativeRBP.java as /native (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/79/head:pull/79` \
`$ git checkout pull/79`

Update a local copy of the PR: \
`$ git checkout pull/79` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/79/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 79`

View PR using the GUI difftool: \
`$ git pr show -t 79`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/79.diff">https://git.openjdk.org/jdk26u/pull/79.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/79#issuecomment-3970536730)
</details>
