### PR TITLE
8373847: Test javax/swing/JMenuItem/MenuItemTest/bug6197830.java failed because The test case automatically fails when clicking any items in the “Nothing” menu in all four windows (Left-to-right)-Menu Item Test and (Right-to-left)-Menu Item Test

### DIFF
--- a/test/jdk/javax/swing/JMenuItem/MenuItemTest/bug6197830.java
+++ b/test/jdk/javax/swing/JMenuItem/MenuItemTest/bug6197830.java
@@ -49,6 +49,7 @@ public class bug6197830 {
                 .columns(35)
                 .testUI(bug6197830::createTestUI)
                 .positionTestUIBottomRowCentered()
+                .logArea()
                 .build()
                 .awaitAndCheck();
     }


### PR DESCRIPTION
This is a backport of JDK-8373847 
bug6197830.java failed with java.lang.NullPointerException when user selected any menu item from "No nothing", because PassFailJFrame logArea was not created. Fixed the test to create log area, and the test passed.

JTREG Testing - Test passed on manual run via JTreg Command.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8373847](https://bugs.openjdk.org/browse/JDK-8373847) needs maintainer approval

### Issue
 * [JDK-8373847](https://bugs.openjdk.org/browse/JDK-8373847): Test javax/swing/JMenuItem/MenuItemTest/bug6197830.java failed because The test case automatically fails when clicking any items in the “Nothing” menu in all four windows (Left-to-right)-Menu Item Test and (Right-to-left)-Menu Item Test (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/80/head:pull/80` \
`$ git checkout pull/80`

Update a local copy of the PR: \
`$ git checkout pull/80` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/80/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 80`

View PR using the GUI difftool: \
`$ git pr show -t 80`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/80.diff">https://git.openjdk.org/jdk26u/pull/80.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/80#issuecomment-3971174579)
</details>
