### PR TITLE
8378871: CPU feature flags are not properly set in vm_version_windows_aarch64.cpp

### DIFF
--- a/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
@@ -27,22 +27,30 @@
 #include "runtime/vm_version.hpp"
 
 int VM_Version::get_current_sve_vector_length() {
-  assert(_features & CPU_SVE, "should not call this");
+  assert(VM_Version::supports_sve(), "should not call this");
   ShouldNotReachHere();
   return 0;
 }
 
 int VM_Version::set_and_get_current_sve_vector_length(int length) {
-  assert(_features & CPU_SVE, "should not call this");
+  assert(VM_Version::supports_sve(), "should not call this");
   ShouldNotReachHere();
   return 0;
 }
 
 void VM_Version::get_os_cpu_info() {
 
-  if (IsProcessorFeaturePresent(PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE))   _features |= CPU_CRC32;
-  if (IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE))  _features |= CPU_AES | CPU_SHA1 | CPU_SHA2;
-  if (IsProcessorFeaturePresent(PF_ARM_VFP_32_REGISTERS_AVAILABLE))        _features |= CPU_ASIMD;
+  if (IsProcessorFeaturePresent(PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE)) {
+    set_feature(CPU_CRC32);
+  }
+  if (IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE)) {
+    set_feature(CPU_AES);
+    set_feature(CPU_SHA1);
+    set_feature(CPU_SHA2);
+  }
+  if (IsProcessorFeaturePresent(PF_ARM_VFP_32_REGISTERS_AVAILABLE)) {
+    set_feature(CPU_ASIMD);
+  }
   // No check for CPU_PMULL, CPU_SVE, CPU_SVE2
 
   __int64 dczid_el0 = _ReadStatusReg(0x5807 /* ARM64_DCZID_EL0 */);


### PR DESCRIPTION
This PR is for backporting https://github.com/openjdk/jdk/commit/20ac1b182eef2af02d017f9e7724fabd60724a33 to 26u. The patch applies cleanly.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8378871](https://bugs.openjdk.org/browse/JDK-8378871) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8378871](https://bugs.openjdk.org/browse/JDK-8378871): CPU feature flags are not properly set in vm_version_windows_aarch64.cpp (**Bug** - P4 - Approved)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/81/head:pull/81` \
`$ git checkout pull/81`

Update a local copy of the PR: \
`$ git checkout pull/81` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/81/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 81`

View PR using the GUI difftool: \
`$ git pr show -t 81`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/81.diff">https://git.openjdk.org/jdk26u/pull/81.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/81#issuecomment-3976368527)
</details>
