### PR TITLE
8376308: java/net/httpclient/CancelRequestTest.java fails intermittently with "Expected CancellationException not received"

### DIFF
--- a/test/jdk/java/net/httpclient/CancelRequestTest.java
+++ b/test/jdk/java/net/httpclient/CancelRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLHandshakeException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -65,6 +64,7 @@ import java.net.http.HttpResponse.BodyHandlers;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -87,11 +87,14 @@ import static java.net.http.HttpOption.H3_DISCOVERY;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 public class CancelRequestTest implements HttpServerAdapters {
 
     private static final Random random = RandomFactory.getRandom();
+    private static final ConcurrentHashMap<String, CountDownLatch> latches
+            = new ConcurrentHashMap<>();
 
     SSLContext sslContext;
     HttpTestServer httpTestServer;    // HTTP/1.1    [ 4 servers ]
@@ -117,6 +120,7 @@ public class CancelRequestTest implements HttpServerAdapters {
     static volatile boolean tasksFailed;
     static final AtomicLong serverCount = new AtomicLong();
     static final AtomicLong clientCount = new AtomicLong();
+    static final AtomicLong requestCount = new AtomicLong();
     static final long start = System.nanoTime();
     public static String now() {
         long now = System.nanoTime() - start;
@@ -278,10 +282,12 @@ public class CancelRequestTest implements HttpServerAdapters {
     // set HTTP/3 version on the request when targeting
     // an HTTP/3 server
     private HttpRequest.Builder requestBuilder(String uri) {
-        var builder = HttpRequest.newBuilder(URI.create(uri));
+        var u = URI.create(uri+"?req="+requestCount.incrementAndGet());
+        var builder = HttpRequest.newBuilder(u);
         if (uri.contains("h3")) {
             builder.version(HTTP_3);
         }
+        builder.setHeader("X-expect-exception", "true");
         return builder;
     }
 
@@ -324,6 +330,24 @@ public class CancelRequestTest implements HttpServerAdapters {
         assertEquals(resp.statusCode(), 200);
     }
 
+    private static void releaseLatches() {
+        // release left over latches
+        for (var latch : latches.values()) {
+            latch.countDown();
+        }
+        latches.clear();
+    }
+
+    private static CountDownLatch addLatchFor(HttpRequest req) {
+        // release left over latches
+        releaseLatches();
+        String key = Objects.requireNonNull(req.uri().getRawQuery(), "query");
+        var latch = new CountDownLatch(1);
+        latches.put(key, latch);
+        out.println(now() + "CountDownLatch " + latch + " added for " + req.uri());
+        return latch;
+    }
+
     @Test(dataProvider = "asyncurls")
     public void testGetSendAsync(String uri, boolean sameClient, boolean mayInterruptIfRunning)
             throws Exception {
@@ -343,18 +367,21 @@ public class CancelRequestTest implements HttpServerAdapters {
                     .GET()
                     .setOption(H3_DISCOVERY, config)
                     .build();
+            var requestLatch = addLatchFor(req);
+
             BodyHandler<String> handler = BodyHandlers.ofString();
             CountDownLatch latch = new CountDownLatch(1);
+            out.println(now() + "Sending (async): " + req.uri());
             CompletableFuture<HttpResponse<String>> response = client.sendAsync(req, handler);
             var cf1 = response.whenComplete((r,t) -> System.out.println(t));
             CompletableFuture<HttpResponse<String>> cf2 = cf1.whenComplete((r,t) -> latch.countDown());
-            out.println("iteration: " + i + ", req: " + req.uri());
+            out.println(now() + "iteration: " + i + ", req sent: " + req.uri());
             out.println("response: " + response);
             out.println("cf1: " + cf1);
             out.println("cf2: " + cf2);
             delay();
             cf1.cancel(mayInterruptIfRunning);
-            out.println("response after cancel: " + response);
+            out.println(now() + "response after cancel: " + response);
             out.println("cf1 after cancel: " + cf1);
             out.println("cf2 after cancel: " + cf2);
             try {
@@ -362,8 +389,10 @@ public class CancelRequestTest implements HttpServerAdapters {
                 assertEquals(body, String.join("", BODY.split("\\|")));
                 throw new AssertionError("Expected CancellationException not received");
             } catch (ExecutionException x) {
-                out.println("Got expected exception: " + x);
+                out.println(now() + "Got expected exception: " + x);
                 assertTrue(isCancelled(x));
+            } finally {
+                requestLatch.countDown();
             }
 
             // Cancelling the request may cause an IOException instead...
@@ -371,7 +400,7 @@ public class CancelRequestTest implements HttpServerAdapters {
             try {
                 cf1.get();
             } catch (CancellationException | ExecutionException x) {
-                out.println("Got expected exception: " + x);
+                out.println(now() + "Got expected exception: " + x);
                 assertTrue(isCancelled(x));
                 hasCancellationException = x instanceof CancellationException;
             }
@@ -393,7 +422,7 @@ public class CancelRequestTest implements HttpServerAdapters {
                 if (mayInterruptIfRunning) {
                     if (CancellationException.class.isAssignableFrom(wrapped.getClass())) {
                         cause = wrapped.getCause();
-                        out.println("CancellationException cause: " + x);
+                        out.println(now() + "CancellationException cause: " + x);
                     } else if (!isCancelled(cause)) {
                         throw new RuntimeException("Unexpected cause: " + cause);
                     }
@@ -403,15 +432,15 @@ public class CancelRequestTest implements HttpServerAdapters {
                     }
                 }
                 if (!IOException.class.isInstance(cause)) {
-                    out.println("Unexpected cause: " + cause.getClass());
+                    out.println(now() + "Unexpected cause: " + cause.getClass());
                     cause.printStackTrace(out);
                 }
                 assertTrue(IOException.class.isAssignableFrom(cause.getClass()));
                 if (mayInterruptIfRunning) {
-                    out.println("Got expected exception: " + wrapped);
+                    out.println(now() + "Got expected exception: " + wrapped);
                     out.println("\tcause: " + cause);
                 } else {
-                    out.println("Unexpected exception: " + wrapped);
+                    out.println(now() + "Unexpected exception: " + wrapped);
                     wrapped.printStackTrace(out);
                     throw x;
                 }
@@ -453,13 +482,13 @@ public class CancelRequestTest implements HttpServerAdapters {
                 @Override
                 public Iterator<byte[]> iterator() {
                     // this is dangerous
-                    out.println("waiting for completion on: " + cancelFuture);
+                    out.println(now() + "waiting for completion on: " + cancelFuture);
                     boolean async = random.nextBoolean();
                     Runnable cancel = () -> {
-                        out.println("Cancelling from " + Thread.currentThread());
+                        out.println(now() + "Cancelling from " + Thread.currentThread());
                         var cf1 = cancelFuture.join();
                         cf1.cancel(mayInterruptIfRunning);
-                        out.println("cancelled " + cf1);
+                        out.println(now() + "cancelled " + cf1);
                     };
                     if (async) executor.execute(cancel);
                     else cancel.run();
@@ -474,16 +503,20 @@ public class CancelRequestTest implements HttpServerAdapters {
                     .POST(HttpRequest.BodyPublishers.ofByteArrays(iterable))
                     .setOption(H3_DISCOVERY, config)
                     .build();
+            var requestLatch = addLatchFor(req);
+
             BodyHandler<String> handler = BodyHandlers.ofString();
             CountDownLatch latch = new CountDownLatch(1);
+            out.println(now() + "Sending (async): " + req.uri());
             CompletableFuture<HttpResponse<String>> response = client.sendAsync(req, handler);
-            var cf1 = response.whenComplete((r,t) -> System.out.println(t));
+            var cf1 = response.whenComplete((r,t) -> System.out.println(now() + t));
             CompletableFuture<HttpResponse<String>> cf2 = cf1.whenComplete((r,t) -> latch.countDown());
+            out.println(now() + "iteration: " + i + ", req sent: " + req.uri());
             out.println("response: " + response);
             out.println("cf1: " + cf1);
             out.println("cf2: " + cf2);
             cancelFuture.complete(cf1);
-            out.println("response after cancel: " + response);
+            out.println(now() + "response after cancel: " + response);
             out.println("cf1 after cancel: " + cf1);
             out.println("cf2 after cancel: " + cf2);
             try {
@@ -491,8 +524,10 @@ public class CancelRequestTest implements HttpServerAdapters {
                 assertEquals(body, String.join("", BODY.split("\\|")));
                 throw new AssertionError("Expected CancellationException not received");
             } catch (ExecutionException x) {
-                out.println("Got expected exception: " + x);
+                out.println(now() + "Got expected exception: " + x);
                 assertTrue(isCancelled(x));
+            } finally {
+                requestLatch.countDown();
             }
 
             // Cancelling the request may cause an IOException instead...
@@ -500,7 +535,7 @@ public class CancelRequestTest implements HttpServerAdapters {
             try {
                 cf1.get();
             } catch (CancellationException | ExecutionException x) {
-                out.println("Got expected exception: " + x);
+                out.println(now() + "Got expected exception: " + x);
                 assertTrue(isCancelled(x));
                 hasCancellationException = x instanceof CancellationException;
             }
@@ -521,7 +556,7 @@ public class CancelRequestTest implements HttpServerAdapters {
                 Throwable cause = wrapped;
                 if (CancellationException.class.isAssignableFrom(wrapped.getClass())) {
                     cause = wrapped.getCause();
-                    out.println("CancellationException cause: " + x);
+                    out.println(now() + "CancellationException cause: " + x);
                 } else if (!isCancelled(cause)) {
                     throw new RuntimeException("Unexpected cause: " + cause);
                 }
@@ -531,10 +566,10 @@ public class CancelRequestTest implements HttpServerAdapters {
                     throw new RuntimeException("Unexpected timeout exception", cause);
                 }
                 if (mayInterruptIfRunning) {
-                    out.println("Got expected exception: " + wrapped);
+                    out.println(now() + "Got expected exception: " + wrapped);
                     out.println("\tcause: " + cause);
                 } else {
-                    out.println("Unexpected exception: " + wrapped);
+                    out.println(now() + "Unexpected exception: " + wrapped);
                     wrapped.printStackTrace(out);
                     throw x;
                 }
@@ -571,7 +606,7 @@ public class CancelRequestTest implements HttpServerAdapters {
 
             Thread main = Thread.currentThread();
             CompletableFuture<Thread> interruptingThread = new CompletableFuture<>();
-            var uriStr = uri + "/post/req=" + i;
+            var uriStr = uri + "/post/i=" + i;
             Runnable interrupt = () -> {
                 Thread current = Thread.currentThread();
                 out.printf("%s Interrupting main from: %s (%s)%n", now(), current, uriStr);
@@ -593,39 +628,42 @@ public class CancelRequestTest implements HttpServerAdapters {
                     .POST(HttpRequest.BodyPublishers.ofByteArrays(iterable))
                     .setOption(H3_DISCOVERY, config)
                     .build();
+            var requestLatch = addLatchFor(req);
+
             String body = null;
             Exception failed = null;
             try {
-                out.println("Sending: " + uriStr);
+                out.println(now() + "Sending: " + req.uri());
                 body = client.send(req, BodyHandlers.ofString()).body();
             } catch (Exception x) {
                 failed = x;
             }
-            out.println(uriStr + ": got result or exception");
+            requestLatch.countDown();
+            out.println(now() + req.uri() + ": got result or exception");
             if (failed instanceof InterruptedException) {
-                out.println(uriStr + ": Got expected exception: " + failed);
+                out.println(now() + req.uri() + ": Got expected exception: " + failed);
             } else if (failed instanceof IOException) {
-                out.println(uriStr + ": got IOException: " + failed);
+                out.println(now() + req.uri() + ": got IOException: " + failed);
                 // that could be OK if the main thread was interrupted
                 // from the main thread: the interrupted status could have
                 // been caught by writing to the socket from the main
                 // thread.
                 if (interruptingThread.isDone() && interruptingThread.get() == main) {
-                    out.println(uriStr + ": Accepting IOException: " + failed);
+                    out.println(now() + req.uri() + ": Accepting IOException: " + failed);
                     failed.printStackTrace(out);
                 } else {
-                    out.println(uriStr + ": unexpected exception: " + failed);
+                    out.println(now() + req.uri() + ": unexpected exception: " + failed);
                     throw failed;
                 }
             } else if (failed != null) {
-                out.println(uriStr + ": unexpected exception: " + failed);
+                out.println(now() + req.uri() + ": unexpected exception: " + failed);
                 throw failed;
             } else {
                 assert failed == null;
-                out.println(uriStr + ": got body: " + body);
+                out.println(now() + req.uri() + ": got body: " + body);
                 assertEquals(body, String.join("", BODY.split("\\|")));
             }
-            out.println("next iteration");
+            out.println(now() + "next iteration");
 
             var error = TRACKER.check(tracker, 2000,
                     (t) -> t.getOutstandingOperations() > 0 || t.getOutstandingSubscribers() > 0,
@@ -704,7 +742,7 @@ public class CancelRequestTest implements HttpServerAdapters {
         } finally {
             if (fail != null) {
                 if (sharedClientName != null) {
-                    System.err.println("Shared client name is: " + sharedClientName);
+                    System.err.println(now() + "Shared client name is: " + sharedClientName);
                 }
                 throw fail;
             }
@@ -723,9 +761,9 @@ public class CancelRequestTest implements HttpServerAdapters {
         @Override
         public void handle(HttpTestExchange t) throws IOException {
             try {
-                out.println("HTTPSlowHandler received request to " + t.getRequestURI());
-                System.err.println("HTTPSlowHandler received request to " + t.getRequestURI());
-
+                out.println(now() + "HTTPSlowHandler received request to " + t.getRequestURI());
+                System.err.println(now() + "HTTPSlowHandler received request to " + t.getRequestURI());
+                var requestLatch = latches.get(t.getRequestURI().getRawQuery());
                 boolean isThreadInterrupt = isThreadInterrupt(t);
                 byte[] req;
                 try (InputStream is = t.getRequestBody()) {
@@ -733,7 +771,7 @@ public class CancelRequestTest implements HttpServerAdapters {
                 }
                 t.sendResponseHeaders(200, -1); // chunked/variable
                 try (OutputStream os = t.getResponseBody()) {
-                    // lets split the response in several chunks...
+                    // let's split the response in several chunks...
                     String msg = (req != null && req.length != 0)
                             ? new String(req, UTF_8)
                             : BODY;
@@ -747,16 +785,29 @@ public class CancelRequestTest implements HttpServerAdapters {
                         } catch (InterruptedException x) {
                             // OK
                         }
-                        out.printf("Server wrote %d bytes%n", req.length);
+                        out.printf(now() + "Server wrote %d bytes%n", req.length);
+                    }
+                    if (requestLatch != null) {
+                        out.printf(now() + "Server awaiting latch %s for %s%n",
+                                requestLatch, t.getRequestURI());
+                        try {
+                            requestLatch.await();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        out.printf(now() + " ...latch released%n");
                     }
                 }
+            } catch (IOException io) {
+                out.println(now() + "HTTPSlowHandler: IOexception is not unexpected: " + io);
+                throw io;
             } catch (Throwable e) {
-                out.println("HTTPSlowHandler: unexpected exception: " + e);
+                out.println(now() + "HTTPSlowHandler: unexpected exception: " + e);
                 e.printStackTrace();
                 throw e;
             } finally {
-                out.printf("HTTPSlowHandler reply sent: %s%n", t.getRequestURI());
-                System.err.printf("HTTPSlowHandler reply sent: %s%n", t.getRequestURI());
+                out.printf(now() + "HTTPSlowHandler reply sent: %s%n", t.getRequestURI());
+                System.err.printf(now() + "HTTPSlowHandler reply sent: %s%n", t.getRequestURI());
             }
         }
     }


### PR DESCRIPTION
Straight Backport. All tests passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8376308](https://bugs.openjdk.org/browse/JDK-8376308) needs maintainer approval

### Issue
 * [JDK-8376308](https://bugs.openjdk.org/browse/JDK-8376308): java/net/httpclient/CancelRequestTest.java fails intermittently with "Expected CancellationException not received" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/82/head:pull/82` \
`$ git checkout pull/82`

Update a local copy of the PR: \
`$ git checkout pull/82` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/82/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 82`

View PR using the GUI difftool: \
`$ git pr show -t 82`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/82.diff">https://git.openjdk.org/jdk26u/pull/82.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/82#issuecomment-3983082491)
</details>
