### PR TITLE
8376151: Test javax/swing/JFileChooser/4966171/bug4966171.java is failing with OOME

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/4966171/bug4966171.java
+++ b/test/jdk/javax/swing/JFileChooser/4966171/bug4966171.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,8 +50,8 @@ public final class bug4966171 {
     }
 
     private static void test() {
-        // Will run the test no more than 10 seconds per L&F
-        long endtime = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        // Will run the test no more than 5 seconds per L&F
+        long endtime = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
         while (System.nanoTime() < endtime) {
             try {
                 var byteOut = new ByteArrayOutputStream();


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [12570be6](https://github.com/openjdk/jdk/commit/12570be64ae2114587e6de4ef79f79be961023b9) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Damon Nguyen on 26 Jan 2026 and was reviewed by Phil Race, Alexander Zvegintsev and Alexey Ivanov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8376151](https://bugs.openjdk.org/browse/JDK-8376151) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8376151](https://bugs.openjdk.org/browse/JDK-8376151): Test javax/swing/JFileChooser/4966171/bug4966171.java is failing with OOME (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/83/head:pull/83` \
`$ git checkout pull/83`

Update a local copy of the PR: \
`$ git checkout pull/83` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/83/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 83`

View PR using the GUI difftool: \
`$ git pr show -t 83`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/83.diff">https://git.openjdk.org/jdk26u/pull/83.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/83#issuecomment-3984572474)
</details>
