### PR TITLE
8376233: Clean up code in Desktop native peer

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDesktopPeer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDesktopPeer.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,6 +120,7 @@ JNI_COCOA_ENTER(env);
         if (appURI == nil
             || [[urlToOpen absoluteString] containsString:[appURI absoluteString]]
             || [[defaultTerminalApp absoluteString] containsString:[appURI absoluteString]]) {
+            [urlToOpen release];
             return -1;
         }
         // Additionally set forPrinting=TRUE for print
@@ -129,6 +130,7 @@ JNI_COCOA_ENTER(env);
     } else if (action == sun_lwawt_macosx_CDesktopPeer_EDIT) {
         if (appURI == nil
             || [[urlToOpen absoluteString] containsString:[appURI absoluteString]]) {
+            [urlToOpen release];
             return -1;
         }
         // for EDIT: if (defaultApp = TerminalApp) then set appURI = DefaultTextEditor
@@ -156,6 +158,7 @@ JNI_COCOA_ENTER(env);
 
     dispatch_semaphore_wait(semaphore, timeout);
 
+    [urlToOpen release];
 JNI_COCOA_EXIT(env);
     return status;
 }

--- a/src/java.desktop/windows/native/libawt/windows/awt_Desktop.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Desktop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,6 +92,8 @@ JNIEXPORT jstring JNICALL Java_sun_awt_windows_WDesktopPeer_ShellExecute
     if (wcscmp(verb_c, L"open") == 0) {
         BOOL isExecutable = SaferiIsExecutableFileType(fileOrUri_c, FALSE);
         if (isExecutable) {
+            JNU_ReleaseStringPlatformChars(env, fileOrUri_j, fileOrUri_c);
+            JNU_ReleaseStringPlatformChars(env, verb_j, verb_c);
             return env->NewStringUTF("Unsupported URI content");
         }
     }


### PR DESCRIPTION
The back port of 8376233 to JDK26u. The patch applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8376233](https://bugs.openjdk.org/browse/JDK-8376233) needs maintainer approval

### Issue
 * [JDK-8376233](https://bugs.openjdk.org/browse/JDK-8376233): Clean up code in Desktop native peer (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/89/head:pull/89` \
`$ git checkout pull/89`

Update a local copy of the PR: \
`$ git checkout pull/89` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/89/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 89`

View PR using the GUI difftool: \
`$ git pr show -t 89`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/89.diff">https://git.openjdk.org/jdk26u/pull/89.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/89#issuecomment-3990525872)
</details>
