### PR TITLE
8371420: Still sporadic failures of gc/TestAlwaysPreTouchBehavior.java#<gcname> on Linux after JDK-8359104

### DIFF
--- a/test/hotspot/jtreg/gc/TestAlwaysPreTouchBehavior.java
+++ b/test/hotspot/jtreg/gc/TestAlwaysPreTouchBehavior.java
@@ -133,13 +133,8 @@ public class TestAlwaysPreTouchBehavior {
     //
 
     public static void main(String [] args) {
-        long rss = WhiteBox.getWhiteBox().rss();
-        System.out.println("RSS: " + rss);
-        long available = WhiteBox.getWhiteBox().hostAvailableMemory();
-        System.out.println("Host available memory: " + available);
-
+        int maxIter = 20;
         long heapSize = 256 * 1024 * 1024;
-
         // On Linux, a JVM that runs with 256M pre-committed heap will use about 60MB (release JVM) RSS. Barring
         // memory pressure that causes us to lose RSS, pretouching should increase RSS to >256MB. So there should be a
         // clear distinction between non-pretouched and pretouched.
@@ -150,12 +145,28 @@ public class TestAlwaysPreTouchBehavior {
         // on the side of disregarding true errors than to produce false positives (if pretouching is broken, at least
         // some of the runs of this test will run on beefy enough machines and show the test as failed).
         long requiredAvailable = 1024 * 1024 * 1024;
-        if (rss == 0) {
-            throw new SkippedException("cannot get RSS?");
-        }
-        if (available > requiredAvailable) {
-            Asserts.assertGreaterThan(rss, minRequiredRss, "RSS of this process(" + rss + "b) should be bigger " +
-                                      "than or equal to heap size(" + heapSize + "b) (available memory: " + available + "). On Linux Kernel < 4.14 RSS can be inaccurate");
+
+        // RSS values we get are sometimes somewhat delayed or inaccurate
+        for (int iter=0; iter < maxIter; iter++) {
+            long rss = WhiteBox.getWhiteBox().rss();
+            System.out.println("RSS: " + rss);
+            long available = WhiteBox.getWhiteBox().hostAvailableMemory();
+            System.out.println("Host available memory: " + available);
+
+            if (rss == 0) {
+                throw new SkippedException("cannot get RSS?");
+            }
+            if (available <= requiredAvailable) {
+                throw new SkippedException("Available memory on host " + available + " is too small, not larger than required available memory " + requiredAvailable);
+            }
+
+            if ((rss < minRequiredRss) && iter < maxIter-1) {
+                System.out.println("We got only an RSS value of " + rss + " but require " + minRequiredRss + ", let's retry!");
+            } else {
+                Asserts.assertGreaterThan(rss, minRequiredRss, "RSS of this process(" + rss + "b) should be bigger " +
+                                          "than or equal to heap size(" + heapSize + "b) (available memory: " + available + "). On Linux Kernel < 4.14 RSS can be inaccurate");
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
Tested Changes Locally for test/hotspot/jtreg/gc/TestAlwaysPreTouchBehavior.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8371420](https://bugs.openjdk.org/browse/JDK-8371420) needs maintainer approval

### Issue
 * [JDK-8371420](https://bugs.openjdk.org/browse/JDK-8371420): Still sporadic failures of gc/TestAlwaysPreTouchBehavior.java#&lt;gcname&gt; on Linux after JDK-8359104 (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/90/head:pull/90` \
`$ git checkout pull/90`

Update a local copy of the PR: \
`$ git checkout pull/90` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/90/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 90`

View PR using the GUI difftool: \
`$ git pr show -t 90`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/90.diff">https://git.openjdk.org/jdk26u/pull/90.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/90#issuecomment-3996204376)
</details>
