### PR TITLE
8375999: com/sun/jndi/ldap/LdapPoolTimeoutTest.java fails sporadically on Windows

### DIFF
--- a/test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java
+++ b/test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -131,6 +131,7 @@ public class LdapPoolTimeoutTest {
                                 || msg.contains("No route to host")
                                 || msg.contains("Timed out waiting for lock")
                                 || msg.contains("Connect timed out")
+                                || msg.contains("Connection timed out")
                                 || msg.contains("Timeout exceeded while waiting for a connection"))) {
                     // got the expected exception
                     System.out.println("Received expected NamingException with message: " + msg);


### PR DESCRIPTION
Straight Backport.Test passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8375999](https://bugs.openjdk.org/browse/JDK-8375999) needs maintainer approval

### Issue
 * [JDK-8375999](https://bugs.openjdk.org/browse/JDK-8375999): com/sun/jndi/ldap/LdapPoolTimeoutTest.java fails sporadically on Windows (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/94/head:pull/94` \
`$ git checkout pull/94`

Update a local copy of the PR: \
`$ git checkout pull/94` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/94/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 94`

View PR using the GUI difftool: \
`$ git pr show -t 94`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/94.diff">https://git.openjdk.org/jdk26u/pull/94.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/94#issuecomment-4005882530)
</details>
