### PR TITLE
8377334: Test framework used by langtools regression tests can produce false positives

### DIFF
--- a/test/langtools/lib/combo/tools/javac/combo/JavacTemplateTestBase.java
+++ b/test/langtools/lib/combo/tools/javac/combo/JavacTemplateTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -246,7 +246,8 @@ public abstract class JavacTemplateTestBase {
                 return destDir;
             }
             else {
-                ct.analyze();
+                ct.call();
+                // Failed result will show up in diags
                 return nullDir;
             }
         }

--- a/test/langtools/tools/javac/records/RecordCompilationTests.java
+++ b/test/langtools/tools/javac/records/RecordCompilationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -335,7 +335,7 @@ class RecordCompilationTests extends CompilationTestCase {
 
         assertFail("compiler.err.invalid.accessor.method.in.record",
                 "public record R(int x) {\n" +
-                        "    static private final j = 0;" +
+                        "    static private final int j = 0;" +
                         "    static public int x() { return j; };" +
                         "}");
     }
@@ -539,10 +539,10 @@ class RecordCompilationTests extends CompilationTestCase {
                 "record R() { void test1() { class X { U u; } } }",
 
                 "interface I { default void test1() { class X { void test2() { System.err.println(localVar); } } } }",
-                "interface I() { default void test1() { class X { void test2() {System.err.println(param);} } } }",
+                "interface I { default void test1() { class X { void test2() {System.err.println(param);} } } }",
                 "interface I { default void test1() { class X { void test2() { System.err.println(instanceField); } } } }",
                 "interface I { default void test1() { class X { T t; } } }",
-                "interface I() { default void test1() { class X {U u;} } }",
+                "interface I { default void test1() { class X {U u;} } }",
 
                 "enum E { A; void test1() { class X { void test2() { System.err.println(localVar); } } } }",
                 "enum E { A; void test1() { class X { void test2() {System.err.println(param);} } } }",

--- a/test/langtools/tools/javac/sealed/SealedCompilationTests.java
+++ b/test/langtools/tools/javac/sealed/SealedCompilationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -855,12 +855,13 @@ class SealedCompilationTests extends CompilationTestCase {
 
     @Test
     void testSealedNonSealedWithOtherModifiers() {
+        // Sup must be static so Sub may be static
         String template1 =
             """
             @interface A {}
 
             class Outer {
-                sealed class Sup { }
+                static sealed class Sup { }
                 # # class Sub extends Sup {}
                 final class Sub2 extends Sub {}
             }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8377334](https://bugs.openjdk.org/browse/JDK-8377334) needs maintainer approval

### Issue
 * [JDK-8377334](https://bugs.openjdk.org/browse/JDK-8377334): Test framework used by langtools regression tests can produce false positives (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/97/head:pull/97` \
`$ git checkout pull/97`

Update a local copy of the PR: \
`$ git checkout pull/97` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/97/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 97`

View PR using the GUI difftool: \
`$ git pr show -t 97`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/97.diff">https://git.openjdk.org/jdk26u/pull/97.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/97#issuecomment-4021039700)
</details>
