### PR TITLE
8378746: ZGC: jdk/jfr/event/gc/detailed/TestZRelocationSetGroupEvent.java intermittent OOME

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/detailed/TestZRelocationSetGroupEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestZRelocationSetGroupEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import jdk.test.lib.jfr.Events;
  * @requires vm.hasJFR & vm.gc.Z
  * @requires vm.flagless
  * @library /test/lib /test/jdk /test/hotspot/jtreg
- * @run main/othervm -XX:+UseZGC -Xmx32M jdk.jfr.event.gc.detailed.TestZRelocationSetGroupEvent
+ * @run main/othervm -XX:+UseZGC -Xmx64M jdk.jfr.event.gc.detailed.TestZRelocationSetGroupEvent
  */
 
 public class TestZRelocationSetGroupEvent {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [e22c95cd](https://github.com/openjdk/jdk/commit/e22c95cd96f823f75e00396b9ce0701b0eb6c3d5) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 9 Mar 2026 and was reviewed by Stefan Karlsson and Albert Mingkun Yang.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8378746](https://bugs.openjdk.org/browse/JDK-8378746) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8378746](https://bugs.openjdk.org/browse/JDK-8378746): ZGC: jdk/jfr/event/gc/detailed/TestZRelocationSetGroupEvent.java intermittent OOME (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/100/head:pull/100` \
`$ git checkout pull/100`

Update a local copy of the PR: \
`$ git checkout pull/100` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 100`

View PR using the GUI difftool: \
`$ git pr show -t 100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/100.diff">https://git.openjdk.org/jdk26u/pull/100.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/100#issuecomment-4023565624)
</details>
