### PR TITLE
8377167: javax/imageio/ReadAbortTest.java throw NPE when x11 unavailable

### DIFF
--- a/test/jdk/javax/imageio/ReadAbortTest.java
+++ b/test/jdk/javax/imageio/ReadAbortTest.java
@@ -30,16 +30,17 @@
  *          calling IIOReadProgressListener.readAborted() for all readers.
  * @run     main ReadAbortTest
  */
+import java.awt.Color;
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.nio.file.Files;
 import java.util.Iterator;
+
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.event.IIOReadProgressListener;
 import javax.imageio.stream.ImageInputStream;
-import java.awt.Color;
-import java.awt.Graphics2D;
-import java.nio.file.Files;
 
 public class ReadAbortTest implements IIOReadProgressListener {
 
@@ -103,7 +104,9 @@ public class ReadAbortTest implements IIOReadProgressListener {
         } catch (Exception e) {
             throw e;
         } finally {
-            Files.delete(file.toPath());
+            if (file != null && file.exists()) {
+                Files.delete(file.toPath());
+            }
         }
     }
 

--- a/test/jdk/javax/imageio/WriteAbortTest.java
+++ b/test/jdk/javax/imageio/WriteAbortTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,15 +30,16 @@
  *          calling IIOWriteProgressListener.readAborted() for all readers.
  * @run     main WriteAbortTest
  */
-import java.awt.image.BufferedImage;
-import java.io.File;
-import javax.imageio.ImageIO;
-import javax.imageio.stream.ImageInputStream;
 import java.awt.Color;
 import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.File;
 import java.nio.file.Files;
+
+import javax.imageio.ImageIO;
 import javax.imageio.ImageWriter;
 import javax.imageio.event.IIOWriteProgressListener;
+import javax.imageio.stream.ImageInputStream;
 import javax.imageio.stream.ImageOutputStream;
 
 public class WriteAbortTest implements IIOWriteProgressListener {
@@ -98,7 +99,9 @@ public class WriteAbortTest implements IIOWriteProgressListener {
                         + format);
             }
         } finally {
-            Files.delete(file.toPath());
+            if (file != null && file.exists()) {
+                Files.delete(file.toPath());
+            }
         }
     }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [d93bd18d](https://github.com/openjdk/jdk/commit/d93bd18d67555ba998735196576c337249f4932b) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 5 Feb 2026 and was reviewed by Phil Race and Sergey Bylokhov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8377167](https://bugs.openjdk.org/browse/JDK-8377167) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8377167](https://bugs.openjdk.org/browse/JDK-8377167): javax/imageio/ReadAbortTest.java throw NPE when x11 unavailable (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/101/head:pull/101` \
`$ git checkout pull/101`

Update a local copy of the PR: \
`$ git checkout pull/101` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 101`

View PR using the GUI difftool: \
`$ git pr show -t 101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/101.diff">https://git.openjdk.org/jdk26u/pull/101.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/101#issuecomment-4023660276)
</details>
