### PR TITLE
8373866: Refactor java/net/httpclient/ThrowingSubscribers*.java tests to use JUnit5

### DIFF
--- a/test/jdk/java/net/httpclient/ThrowingSubscribersAsInputStream.java
+++ b/test/jdk/java/net/httpclient/ThrowingSubscribersAsInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,14 +29,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker ThrowingSubscribersAsInputStream AbstractThrowingSubscribers
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsInputStream
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsInputStream
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingSubscribersAsInputStream extends AbstractThrowingSubscribers {
 
-    @Test(dataProvider = "variants")
+    @ParameterizedTest
+    @MethodSource("variants")
     public void testThrowingAsInputStream(String uri, boolean sameClient, Thrower thrower)
             throws Exception {
         super.testThrowingAsInputStreamImpl(uri, sameClient, thrower);

--- a/test/jdk/java/net/httpclient/ThrowingSubscribersAsInputStreamAsync.java
+++ b/test/jdk/java/net/httpclient/ThrowingSubscribersAsInputStreamAsync.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,14 +29,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker ThrowingSubscribersAsInputStreamAsync AbstractThrowingSubscribers
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsInputStreamAsync
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsInputStreamAsync
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingSubscribersAsInputStreamAsync extends AbstractThrowingSubscribers {
 
-    @Test(dataProvider = "variants")
+    @ParameterizedTest
+    @MethodSource("variants")
     public void testThrowingAsInputStreamAsync(String uri, boolean sameClient, Thrower thrower)
             throws Exception {
         super.testThrowingAsInputStreamAsyncImpl(uri, sameClient, thrower);

--- a/test/jdk/java/net/httpclient/ThrowingSubscribersAsLimiting.java
+++ b/test/jdk/java/net/httpclient/ThrowingSubscribersAsLimiting.java
@@ -35,18 +35,20 @@
  *        ReferenceTracker
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
  *        jdk.test.lib.net.SimpleSSLContext
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsLimiting
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsLimiting
  */
 
-import org.testng.annotations.Test;
 
 import java.net.http.HttpResponse;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingSubscribersAsLimiting extends AbstractThrowingSubscribers {
 
-    @Test(dataProvider = "variants")
+    @ParameterizedTest
+    @MethodSource("variants")
     public void test(String uri, boolean sameClient, Thrower thrower) throws Exception {
         test(uri, sameClient, thrower, false);
     }

--- a/test/jdk/java/net/httpclient/ThrowingSubscribersAsLimitingAsync.java
+++ b/test/jdk/java/net/httpclient/ThrowingSubscribersAsLimitingAsync.java
@@ -35,15 +35,17 @@
  *        ReferenceTracker
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
  *        jdk.test.lib.net.SimpleSSLContext
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsLimitingAsync
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsLimitingAsync
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingSubscribersAsLimitingAsync extends ThrowingSubscribersAsLimiting {
 
     @Override
-    @Test(dataProvider = "variants")
+    @ParameterizedTest
+    @MethodSource("variants")
     public void test(String uri, boolean sameClient, Thrower thrower) throws Exception {
         test(uri, sameClient, thrower, true);
     }

--- a/test/jdk/java/net/httpclient/ThrowingSubscribersAsLines.java
+++ b/test/jdk/java/net/httpclient/ThrowingSubscribersAsLines.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,14 +29,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker ThrowingSubscribersAsLines AbstractThrowingSubscribers
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsLines
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsLines
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingSubscribersAsLines extends AbstractThrowingSubscribers {
 
-    @Test(dataProvider = "variants")
+    @ParameterizedTest
+    @MethodSource("variants")
     public void testThrowingAsLines(String uri, boolean sameClient, Thrower thrower)
             throws Exception {
         super.testThrowingAsLinesImpl(uri, sameClient, thrower);

--- a/test/jdk/java/net/httpclient/ThrowingSubscribersAsLinesAsync.java
+++ b/test/jdk/java/net/httpclient/ThrowingSubscribersAsLinesAsync.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,14 +29,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker ThrowingSubscribersAsLinesAsync AbstractThrowingSubscribers
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsLinesAsync
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsLinesAsync
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingSubscribersAsLinesAsync extends AbstractThrowingSubscribers {
 
-    @Test(dataProvider = "variants")
+    @ParameterizedTest
+    @MethodSource("variants")
     public void testThrowingAsLinesAsync(String uri, boolean sameClient, Thrower thrower)
             throws Exception {
         super.testThrowingAsLinesAsyncImpl(uri, sameClient, thrower);

--- a/test/jdk/java/net/httpclient/ThrowingSubscribersAsString.java
+++ b/test/jdk/java/net/httpclient/ThrowingSubscribersAsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,14 +29,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker ThrowingSubscribersAsString AbstractThrowingSubscribers
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsString
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsString
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingSubscribersAsString extends AbstractThrowingSubscribers {
 
-    @Test(dataProvider = "variants")
+    @ParameterizedTest
+    @MethodSource("variants")
     public void testThrowingAsString(String uri, boolean sameClient, Thrower thrower)
             throws Exception {
         super.testThrowingAsStringImpl(uri, sameClient, thrower);

--- a/test/jdk/java/net/httpclient/ThrowingSubscribersAsStringAsync.java
+++ b/test/jdk/java/net/httpclient/ThrowingSubscribersAsStringAsync.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,14 +29,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker ThrowingSubscribersAsStringAsync AbstractThrowingSubscribers
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsStringAsync
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsStringAsync
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingSubscribersAsStringAsync extends AbstractThrowingSubscribers {
 
-    @Test(dataProvider = "variants")
+    @ParameterizedTest
+    @MethodSource("variants")
     public void testThrowingAsStringAsync(String uri, boolean sameClient, Thrower thrower)
             throws Exception {
         super.testThrowingAsStringAsyncImpl(uri, sameClient, thrower);

--- a/test/jdk/java/net/httpclient/ThrowingSubscribersSanity.java
+++ b/test/jdk/java/net/httpclient/ThrowingSubscribersSanity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,14 +29,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker ThrowingSubscribersSanity AbstractThrowingSubscribers
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersSanity
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersSanity
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingSubscribersSanity extends AbstractThrowingSubscribers {
 
-    @Test(dataProvider = "sanity")
+    @ParameterizedTest
+    @MethodSource("sanity")
     public void testSanity(String uri, boolean sameClient)
             throws Exception {
         super.testSanityImpl(uri, sameClient);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8373866](https://bugs.openjdk.org/browse/JDK-8373866) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8373866](https://bugs.openjdk.org/browse/JDK-8373866): Refactor java/net/httpclient/ThrowingSubscribers*.java tests to use JUnit5 (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/107/head:pull/107` \
`$ git checkout pull/107`

Update a local copy of the PR: \
`$ git checkout pull/107` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 107`

View PR using the GUI difftool: \
`$ git pr show -t 107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/107.diff">https://git.openjdk.org/jdk26u/pull/107.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/107#issuecomment-4038948636)
</details>
