### PR TITLE
8368524: Tests are skipped and shown as passed in test/jdk/sun/security/pkcs11/Cipher/KeyWrap

### DIFF
--- a/test/jdk/sun/security/pkcs11/Cipher/KeyWrap/NISTWrapKAT.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/KeyWrap/NISTWrapKAT.java
@@ -83,7 +83,7 @@ public class NISTWrapKAT extends PKCS11Test {
     private static String KEK2 =
             "5840DF6E29B02AF1AB493B705BF16EA1AE8338F4DCC176A8";
 
-    private static final List<String> skippedList = new ArrayList <>();
+    private static final List<String> skippedAlgoList = new ArrayList <>();
 
     private static byte[] toBytes(String hex, int hexLen) {
         if (hexLen < hex.length()) {
@@ -274,8 +274,8 @@ public class NISTWrapKAT extends PKCS11Test {
             dataLen + "-byte key with " + 8*keyLen + "-bit KEK");
         int allowed = Cipher.getMaxAllowedKeyLength("AES");
         if (keyLen > allowed) {
-            System.out.println("=> skip, exceeds max allowed size " + allowed);
-            skippedList.add(algo + " Cipher with wrapping " +
+            System.err.println("Skip, exceeds max allowed size " + allowed);
+            skippedAlgoList.add(algo + " Cipher with wrapping " +
                             dataLen + "-byte key with " + 8 * keyLen +
                             "-bit KEK exceeds max allowed size " + allowed);
             return;
@@ -344,8 +344,8 @@ public class NISTWrapKAT extends PKCS11Test {
             dataLen + "-byte data with " + 8*keyLen + "-bit KEK");
         int allowed = Cipher.getMaxAllowedKeyLength("AES");
         if (keyLen > allowed) {
-            System.out.println("=> skip, exceeds max allowed size " + allowed);
-            skippedList.add(algo + " Cipher with enc " +
+            System.err.println("Skip, exceeds max allowed size " + allowed);
+            skippedAlgoList.add(algo + " Cipher with enc " +
                             dataLen + "-byte data with " + 8 * keyLen +
                             "-bit KEK exceeds max allowed size " + allowed);
             return;
@@ -416,7 +416,9 @@ public class NISTWrapKAT extends PKCS11Test {
         for (Object[] td : testDatum) {
             String algo = (String) td[0];
             if (p.getService("Cipher", algo) == null) {
-                skippedList.add("No support for " + algo);
+                System.err.println("Skip, due to no support:  " + algo);
+                skippedAlgoList.add("No support for " + algo);
+                continue;
             }
             testKeyWrap(algo, (String) td[1], (int) td[2], (String) td[3],
                     (int) td[4], (String) td[5], p);
@@ -424,9 +426,9 @@ public class NISTWrapKAT extends PKCS11Test {
                     (int) td[4], (String) td[5], p);
         }
 
-        if (!skippedList.isEmpty()) {
+        if (!skippedAlgoList.isEmpty()) {
             throw new SkippedException("One or more tests skipped "
-                                       + skippedList);
+                    + skippedAlgoList);
         } else {
             System.out.println("All Tests Passed");
         }

--- a/test/jdk/sun/security/pkcs11/Cipher/KeyWrap/TestGeneral.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/KeyWrap/TestGeneral.java
@@ -273,6 +273,7 @@ public class TestGeneral extends PKCS11Test {
         for (String a : algos) {
             if (p.getService("Cipher", a) == null) {
                 skippedList.add(a);
+                continue;
             }
 
             System.out.println("Testing " + a);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8368524](https://bugs.openjdk.org/browse/JDK-8368524) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368524](https://bugs.openjdk.org/browse/JDK-8368524): Tests are skipped and shown as passed in test/jdk/sun/security/pkcs11/Cipher/KeyWrap (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/108/head:pull/108` \
`$ git checkout pull/108`

Update a local copy of the PR: \
`$ git checkout pull/108` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 108`

View PR using the GUI difftool: \
`$ git pr show -t 108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/108.diff">https://git.openjdk.org/jdk26u/pull/108.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/108#issuecomment-4044790835)
</details>
