### PR TITLE
8374711: Hotspot runtime/CommandLine/OptionsValidation/TestOptionsWithRanges fails without printing the option name

### DIFF
--- a/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/common/optionsvalidation/JVMOption.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/common/optionsvalidation/JVMOption.java
@@ -116,7 +116,7 @@ public abstract class JVMOption {
             default:
                 throw new Error("Expected only \"int\", \"intx\", \"size_t\", "
                         + "\"uint\", \"uintx\", \"uint64_t\", or \"double\" "
-                        + "option types! Got " + type + " type!");
+                        + "option types! Got " + type + " type for option " + name + "!");
         }
 
         return parameter;


### PR DESCRIPTION
Changes Tested Locally for runtime/CommandLine/OptionsValidation/TestOptionsWithRanges.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8374711](https://bugs.openjdk.org/browse/JDK-8374711) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8374711](https://bugs.openjdk.org/browse/JDK-8374711): Hotspot runtime/CommandLine/OptionsValidation/TestOptionsWithRanges fails without printing the option name (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/109/head:pull/109` \
`$ git checkout pull/109`

Update a local copy of the PR: \
`$ git checkout pull/109` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 109`

View PR using the GUI difftool: \
`$ git pr show -t 109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/109.diff">https://git.openjdk.org/jdk26u/pull/109.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/109#issuecomment-4046297635)
</details>
