### PR TITLE
8373120: Virtual thread stuck in BLOCKED state

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/stress/NotifiedThenTimedOutWait.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/NotifiedThenTimedOutWait.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8373120
+ * @summary Stress test two consecutive timed Object.wait calls where only the first one is notified.
+ * @run main/othervm -XX:CompileCommand=exclude,java.lang.VirtualThread::afterYield NotifiedThenTimedOutWait 1 100 100
+ */
+
+/*
+ * @test
+ * @run main/othervm -XX:CompileCommand=exclude,java.lang.VirtualThread::afterYield NotifiedThenTimedOutWait 2 100 100
+ */
+
+import java.time.Instant;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class NotifiedThenTimedOutWait {
+    public static void main(String[] args) throws Exception {
+        int race = (args.length > 0) ? Integer.parseInt(args[0]) : 1;
+        int nruns = (args.length > 1) ? Integer.parseInt(args[1]) : 100;
+        int iterations = (args.length > 2) ? Integer.parseInt(args[2]) : 100;
+
+        for (int i = 1; i <= nruns; i++) {
+            System.out.println(Instant.now() + " => " + i + " of " + nruns);
+            switch (race) {
+                case 1 -> race1(iterations);
+                case 2 -> race2(iterations);
+            }
+        }
+    }
+
+    /**
+     * Barrier in synchronized block.
+     */
+    private static void race1(int iterations) throws InterruptedException {
+        final int timeout = 1;
+        var lock = new Object();
+        var start = new Phaser(2);
+        var end = new Phaser(2);
+
+        var vthread = Thread.ofVirtual().start(() -> {
+            try {
+                for (int j = 0; j < iterations; j++) {
+                    synchronized (lock) {
+                        start.arriveAndAwaitAdvance();
+                        lock.wait(timeout);
+                        lock.wait(timeout);
+                    }
+                    end.arriveAndAwaitAdvance();
+                }
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        });
+
+        ThreadFactory factory = ThreadLocalRandom.current().nextBoolean()
+                    ? Thread.ofPlatform().factory() : Thread.ofVirtual().factory();
+        var notifier = factory.newThread(() -> {
+            for (int j = 0; j < iterations; j++) {
+                start.arriveAndAwaitAdvance();
+                synchronized (lock) {
+                    lock.notify();
+                }
+                end.arriveAndAwaitAdvance();
+            }
+        });
+        notifier.start();
+
+        vthread.join();
+        notifier.join();
+    }
+
+    /**
+     * Barrier before synchronized block.
+     */
+    private static void race2(int iterations) throws InterruptedException {
+        final int timeout = 1;
+        var lock = new Object();
+        var start = new Phaser(2);
+
+        var vthread = Thread.startVirtualThread(() -> {
+            try {
+                for (int i = 0; i < iterations; i++) {
+                    start.arriveAndAwaitAdvance();
+                    synchronized (lock) {
+                        lock.wait(timeout);
+                        lock.wait(timeout);
+                    }
+                }
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        });
+
+        ThreadFactory factory = ThreadLocalRandom.current().nextBoolean()
+                    ? Thread.ofPlatform().factory() : Thread.ofVirtual().factory();
+        var notifier = factory.newThread(() -> {
+            for (int i = 0; i < iterations; i++) {
+                start.arriveAndAwaitAdvance();
+                synchronized (lock) {
+                    lock.notify();
+                }
+            }
+        });
+        notifier.start();
+
+        vthread.join();
+        notifier.join();
+    }
+}


### PR DESCRIPTION
Fixes another Virtual Thread issue that manifests in JDK 26.

Additional testing:
 - [x] New regression test passes; 1000x iterations
 - [x] Linux x86_64 server fastdebug, `jdk_loom hotspot_loom`, 10x
 - [x] Linux x86_64 server fastdebug, `java/lang/Thread/virtual/stress/`, 10x

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8373120](https://bugs.openjdk.org/browse/JDK-8373120) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8373120](https://bugs.openjdk.org/browse/JDK-8373120): Virtual thread stuck in BLOCKED state (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/111/head:pull/111` \
`$ git checkout pull/111`

Update a local copy of the PR: \
`$ git checkout pull/111` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 111`

View PR using the GUI difftool: \
`$ git pr show -t 111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/111.diff">https://git.openjdk.org/jdk26u/pull/111.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/111#issuecomment-4053628515)
</details>
