### PR TITLE
8376104: C2 crashes in PhiNode::Ideal(PhaseGVN*, bool) accessing NULL pointer

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2610,6 +2610,10 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     for( uint i=1; i<req(); ++i ) {// For all paths in
       Node *ii = in(i);
       Node *new_in = MemNode::optimize_memory_chain(ii, at, nullptr, phase);
+      // MemNode::optimize_memory_chain above may kill us!
+      if (outcnt() == 0) {
+        return top;
+      }
       if (ii != new_in ) {
         set_req_X(i, new_in, phase);
         progress = this;


### PR DESCRIPTION
Backporting [JDK-8376104](https://bugs.openjdk.org/browse/JDK-8376104) C2 crashes in PhiNode::Ideal(PhaseGVN*, bool) accessing NULL pointer

This PR backports the fix for C2 segmentation fault that occurs on nullptr dereferencing when the call to `MemNode::optimize_memory_chain` within `PhiNode::Ideal` can kill the Phi node itself.

tier1 is OK

`make test TEST=hotspot_compiler` is OK

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8376104](https://bugs.openjdk.org/browse/JDK-8376104) needs maintainer approval

### Issue
 * [JDK-8376104](https://bugs.openjdk.org/browse/JDK-8376104): C2 crashes in PhiNode::Ideal(PhaseGVN*, bool) accessing NULL pointer (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/112/head:pull/112` \
`$ git checkout pull/112`

Update a local copy of the PR: \
`$ git checkout pull/112` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 112`

View PR using the GUI difftool: \
`$ git pr show -t 112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/112.diff">https://git.openjdk.org/jdk26u/pull/112.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/112#issuecomment-4053746966)
</details>
