### PR TITLE
8372377: Test java/io/File/GetXSpace.java failed: The system cannot find the path specified

### DIFF
--- a/test/jdk/java/io/File/GetXSpace.java
+++ b/test/jdk/java/io/File/GetXSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import jdk.test.lib.Platform;
 import jdk.test.lib.Platform;
 
 import static java.lang.System.err;
@@ -103,16 +102,11 @@ public class GetXSpace {
         private final long free;
         private final long available;
 
-        Space(String name) {
+        Space(String name) throws IOException {
             this.name = name;
             long[] sizes = new long[4];
             if (Platform.isWindows() && isCDDrive(name)) {
-                try {
-                    getCDDriveSpace(name, sizes);
-                } catch (IOException e) {
-                    e.printStackTrace();
-                    throw new RuntimeException("can't get CDDrive sizes");
-                }
+                getCDDriveSpace(name, sizes);
             } else {
                 if (getSpace(name, sizes))
                     System.err.println("WARNING: total space is estimated");
@@ -170,7 +164,7 @@ public class GetXSpace {
         return al;
     }
 
-    private static void compare(Space s) {
+    private static void compare(Space s) throws IOException {
         File f = new File(s.name());
         long ts = f.getTotalSpace();
         long fs = f.getFreeSpace();
@@ -318,7 +312,7 @@ public class GetXSpace {
         }
     }
 
-    private static int testFile(Path dir) {
+    private static int testFile(Path dir) throws IOException {
         String dirName = dir.toString();
         out.format("--- Testing %s%n", dirName);
         compare(new Space(dir.getRoot().toString()));
@@ -333,10 +327,11 @@ public class GetXSpace {
         return fail != 0 ? 1 : 0;
     }
 
-    private static int testVolumes() {
+    private static int testVolumes() throws IOException {
         out.println("--- Testing volumes");
         // Find all of the partitions on the machine and verify that the sizes
-        // returned by File::getXSpace are equivalent to those from getSpace or getCDDriveSpace
+        // returned by File::getXSpace are equivalent to those from getSpace
+        // or getCDDriveSpace
         ArrayList<String> l;
         try {
             l = paths();
@@ -350,7 +345,18 @@ public class GetXSpace {
             throw new RuntimeException("no partitions?");
 
         for (var p : l) {
-            Space s = new Space(p);
+            Space s;
+            try {
+                s = new Space(p);
+            } catch (IOException x) {
+                // Avoid failing for transient file systems on Windows
+                if (Platform.isWindows()) {
+                    File f = new File(p);
+                    if (!f.exists())
+                        continue;
+                }
+                throw new IOException("Failure for volume " + p, x);
+            }
             compare(s);
             compareZeroNonExist();
             compareZeroExist();
@@ -408,19 +414,19 @@ public class GetXSpace {
     // size[2]  free space:   number of free bytes in the volume
     // size[3]  usable space: number of bytes available to the caller
     //
-    private static native boolean getSpace0(String root, long[] space);
+    private static native boolean getSpace0(String root, long[] space)
+        throws IOException;
 
     private static native boolean isCDDrive(String root);
 
-    private static boolean getSpace(String root, long[] space) {
+    private static boolean getSpace(String root, long[] space)
+        throws IOException {
         try {
             return getSpace0(root, space);
-        } catch (RuntimeException e) {
+        } catch (IOException e) {
             File f = new File(root);
-            boolean exists = f.exists();
-            boolean readable = f.canRead();
             System.err.printf("getSpace0 failed for %s (%s, %s)%n",
-                              root, exists, readable);
+                              root, f.exists(), f.canRead());
             throw e;
         }
     }

--- a/test/jdk/java/io/File/libGetXSpace.c
+++ b/test/jdk/java/io/File/libGetXSpace.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,7 +85,7 @@ Java_GetXSpace_getSpace0
         BOOL hres = pfnGetDiskSpaceInformation(path, &diskSpaceInfo);
         (*env)->ReleaseStringChars(env, root, strchars);
         if (FAILED(hres)) {
-            JNU_ThrowByNameWithLastError(env, "java/lang/RuntimeException",
+            JNU_ThrowByNameWithLastError(env, "java/io/IOException",
                                          "GetDiskSpaceInformationW");
             return totalSpaceIsEstimated;
         }
@@ -113,7 +113,7 @@ Java_GetXSpace_getSpace0
             &totalNumberOfBytes, &totalNumberOfFreeBytes);
         (*env)->ReleaseStringChars(env, root, strchars);
         if (FAILED(hres)) {
-            JNU_ThrowByNameWithLastError(env, "java/lang/RuntimeException",
+            JNU_ThrowByNameWithLastError(env, "java/io/IOException",
                                          "GetDiskFreeSpaceExW");
             return totalSpaceIsEstimated;
         }
@@ -131,8 +131,7 @@ Java_GetXSpace_getSpace0
     char* chars = (char*)malloc((len + 1)*sizeof(char));
     if (chars == NULL) {
         (*env)->ReleaseStringChars(env, root, strchars);
-        JNU_ThrowByNameWithLastError(env, "java/lang/RuntimeException",
-                                     "malloc");
+        JNU_ThrowOutOfMemoryError(env, "malloc");
         return JNI_FALSE;
     }
 
@@ -146,7 +145,7 @@ Java_GetXSpace_getSpace0
     int result = statfs(chars, &buf);
     free(chars);
     if (result < 0) {
-        JNU_ThrowByNameWithLastError(env, "java/lang/RuntimeException",
+        JNU_ThrowByNameWithLastError(env, "java/io/IOException",
                                      strerror(errno));
         return totalSpaceIsEstimated;
     }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8372377](https://bugs.openjdk.org/browse/JDK-8372377) needs maintainer approval

### Issue
 * [JDK-8372377](https://bugs.openjdk.org/browse/JDK-8372377): Test java/io/File/GetXSpace.java failed: The system cannot find the path specified (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/113/head:pull/113` \
`$ git checkout pull/113`

Update a local copy of the PR: \
`$ git checkout pull/113` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 113`

View PR using the GUI difftool: \
`$ git pr show -t 113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/113.diff">https://git.openjdk.org/jdk26u/pull/113.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/113#issuecomment-4073464611)
</details>
