### PR TITLE
8378727: [macOS] Missing dispatch_release for semaphores in CDesktopPeer

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDesktopPeer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDesktopPeer.m
@@ -70,6 +70,7 @@ JNI_COCOA_ENTER(env);
     dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(NSEC_PER_SEC)); // 1 second timeout
 
     // Asynchronous call to openURL
+    dispatch_retain(semaphore);
     [[NSWorkspace sharedWorkspace] openURLs:urls
                                     withApplicationAtURL:appURI
                                     configuration:configuration
@@ -78,9 +79,11 @@ JNI_COCOA_ENTER(env);
             status = (OSStatus) error.code;
         }
         dispatch_semaphore_signal(semaphore);
+        dispatch_release(semaphore);
     }];
 
     dispatch_semaphore_wait(semaphore, timeout);
+    dispatch_release(semaphore);
 
 JNI_COCOA_EXIT(env);
     return status;
@@ -146,6 +149,7 @@ JNI_COCOA_ENTER(env);
     dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(NSEC_PER_SEC)); // 1 second timeout
 
     // Asynchronous call - openURLs:withApplicationAtURL
+    dispatch_retain(semaphore);
     [[NSWorkspace sharedWorkspace] openURLs:urls
                                    withApplicationAtURL:appURI
                                    configuration:configuration
@@ -154,9 +158,11 @@ JNI_COCOA_ENTER(env);
             status = (OSStatus) error.code;
         }
         dispatch_semaphore_signal(semaphore);
+        dispatch_release(semaphore);
     }];
 
     dispatch_semaphore_wait(semaphore, timeout);
+    dispatch_release(semaphore);
 
     [urlToOpen release];
 JNI_COCOA_EXIT(env);


### PR DESCRIPTION
The back port of 8378727 to JDK26u. The patch applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8378727](https://bugs.openjdk.org/browse/JDK-8378727) needs maintainer approval

### Issue
 * [JDK-8378727](https://bugs.openjdk.org/browse/JDK-8378727): [macOS] Missing dispatch_release for semaphores in CDesktopPeer (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/116/head:pull/116` \
`$ git checkout pull/116`

Update a local copy of the PR: \
`$ git checkout pull/116` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 116`

View PR using the GUI difftool: \
`$ git pr show -t 116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/116.diff">https://git.openjdk.org/jdk26u/pull/116.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/116#issuecomment-4088768439)
</details>
