### PR TITLE
8380078: Update GIFlib to 6.1.2

### DIFF
--- a/src/java.desktop/share/legal/giflib.md
+++ b/src/java.desktop/share/legal/giflib.md
@@ -1,4 +1,4 @@
-## GIFLIB v6.1.1
+## GIFLIB v6.1.2
 
 ### GIFLIB License
 ```

--- a/src/java.desktop/share/native/libsplashscreen/giflib/gif_lib.h
+++ b/src/java.desktop/share/native/libsplashscreen/giflib/gif_lib.h
@@ -39,7 +39,7 @@ extern "C" {
 
 #define GIFLIB_MAJOR 6
 #define GIFLIB_MINOR 1
-#define GIFLIB_RELEASE 1
+#define GIFLIB_RELEASE 2
 
 #define GIF_ERROR 0
 #define GIF_OK 1

--- a/src/java.desktop/share/native/libsplashscreen/giflib/gifalloc.c
+++ b/src/java.desktop/share/native/libsplashscreen/giflib/gifalloc.c
@@ -373,6 +373,14 @@ SavedImage *GifMakeSavedImage(GifFileType *GifFile,
                          * aliasing problems.
                          */
 
+                        /* Null out aliased pointers before any allocations
+                         * so that FreeLastSavedImage won't free CopyFrom's
+                         * data if an allocation fails partway through. */
+                        sp->ImageDesc.ColorMap = NULL;
+                        sp->RasterBits = NULL;
+                        sp->ExtensionBlocks = NULL;
+                        sp->ExtensionBlockCount = 0;
+
                         /* first, the local color map */
                         if (CopyFrom->ImageDesc.ColorMap != NULL) {
                                 sp->ImageDesc.ColorMap = GifMakeMapObject(


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [76e7c9e6](https://github.com/openjdk/jdk/commit/76e7c9e68a42b41df1f309815d9f0111fd967d1f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Damon Nguyen on 19 Mar 2026 and was reviewed by Sergey Bylokhov and Alexander Zvegintsev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Issue
 * [JDK-8380078](https://bugs.openjdk.org/browse/JDK-8380078): Update GIFlib to 6.1.2 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/121/head:pull/121` \
`$ git checkout pull/121`

Update a local copy of the PR: \
`$ git checkout pull/121` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 121`

View PR using the GUI difftool: \
`$ git pr show -t 121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/121.diff">https://git.openjdk.org/jdk26u/pull/121.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/121#issuecomment-4099588983)
</details>
