### PR TITLE
8379952: Revert JDK-8365711: Restore protected visibility of menuBarHeight and hotTrackingOn

### DIFF
--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuUI.java
@@ -51,8 +51,8 @@ import com.sun.java.swing.plaf.windows.TMSchema.State;
  * Windows rendition of the component.
  */
 public final class WindowsMenuUI extends BasicMenuUI {
-    private Integer menuBarHeight;
-    private boolean hotTrackingOn;
+    protected Integer menuBarHeight;
+    protected boolean hotTrackingOn;
 
     final WindowsMenuItemUIAccessor accessor =
         new WindowsMenuItemUIAccessor() {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [30145a4b](https://github.com/openjdk/jdk/commit/30145a4bd7919d5e616251056903826d3ab01702) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 18 Mar 2026 and was reviewed by Alexander Zvegintsev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8379952](https://bugs.openjdk.org/browse/JDK-8379952) needs maintainer approval

### Issue
 * [JDK-8379952](https://bugs.openjdk.org/browse/JDK-8379952): Revert JDK-8365711: Restore protected visibility of menuBarHeight and hotTrackingOn (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/122/head:pull/122` \
`$ git checkout pull/122`

Update a local copy of the PR: \
`$ git checkout pull/122` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 122`

View PR using the GUI difftool: \
`$ git pr show -t 122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/122.diff">https://git.openjdk.org/jdk26u/pull/122.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/122#issuecomment-4111982025)
</details>
