### PR TITLE
8379499: [AIX] headless-only build of libjawt.so fails

### DIFF
--- a/make/modules/java.desktop/lib/AwtLibraries.gmk
+++ b/make/modules/java.desktop/lib/AwtLibraries.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -421,6 +421,9 @@ ifeq ($(call isTargetOs, macosx), true)
 endif
 
 ifeq ($(call isTargetOs, linux)+$(ENABLE_HEADLESS_ONLY), true+true)
+  LIBJAWT_CFLAGS += -DHEADLESS
+endif
+ifeq ($(call isTargetOs, aix)+$(ENABLE_HEADLESS_ONLY), true+true)
   LIBJAWT_CFLAGS += -DHEADLESS
 endif
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8379499](https://bugs.openjdk.org/browse/JDK-8379499) needs maintainer approval

### Issue
 * [JDK-8379499](https://bugs.openjdk.org/browse/JDK-8379499): [AIX] headless-only build of libjawt.so fails (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/127/head:pull/127` \
`$ git checkout pull/127`

Update a local copy of the PR: \
`$ git checkout pull/127` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 127`

View PR using the GUI difftool: \
`$ git pr show -t 127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/127.diff">https://git.openjdk.org/jdk26u/pull/127.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/127#issuecomment-4118175554)
</details>
