### PR TITLE
8374371: Failed assertion in G1HeapRegion gtest

### DIFF
--- a/test/hotspot/gtest/gc/g1/test_heapRegion.cpp
+++ b/test/hotspot/gtest/gc/g1/test_heapRegion.cpp
@@ -79,7 +79,6 @@ void VM_HeapRegionApplyToMarkedObjectsTest::doit() {
   bitmap->par_mark(region->bottom() + MARK_OFFSET_1);
   bitmap->par_mark(region->bottom() + MARK_OFFSET_2);
   bitmap->par_mark(region->bottom() + MARK_OFFSET_3);
-  bitmap->par_mark(region->end());
 
   VerifyAndCountMarkClosure cl(bitmap);
 


### PR DESCRIPTION
Hi all,

  This pull request contains a backport of commit [65af6bcb](https://github.com/openjdk/jdk/commit/65af6bcb8f74484436b0331032260f2a646f203f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Kim Barrett on 2 Jan 2026 and was reviewed by Thomas Schatzl and Ivan Walulya.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8374371](https://bugs.openjdk.org/browse/JDK-8374371) needs maintainer approval

### Issue
 * [JDK-8374371](https://bugs.openjdk.org/browse/JDK-8374371): Failed assertion in G1HeapRegion gtest (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/128/head:pull/128` \
`$ git checkout pull/128`

Update a local copy of the PR: \
`$ git checkout pull/128` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 128`

View PR using the GUI difftool: \
`$ git pr show -t 128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/128.diff">https://git.openjdk.org/jdk26u/pull/128.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/128#issuecomment-4118176582)
</details>
