### PR TITLE
8378836: Enable linktime-gc by default on Linux ppc64le

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -103,8 +103,12 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_JDK_OPTIONS],
   AC_SUBST(ENABLE_HEADLESS_ONLY)
 
   # should we linktime gc unused code sections in the JDK build ?
-  if test "x$OPENJDK_TARGET_OS" = "xlinux" && test "x$OPENJDK_TARGET_CPU" = xs390x; then
-    LINKTIME_GC_DEFAULT=true
+  if test "x$OPENJDK_TARGET_OS" = "xlinux"; then
+    if test "x$OPENJDK_TARGET_CPU" = "xs390x" || test "x$OPENJDK_TARGET_CPU" = "xppc64le"; then
+      LINKTIME_GC_DEFAULT=true
+    else
+      LINKTIME_GC_DEFAULT=false
+    fi
   else
     LINKTIME_GC_DEFAULT=false
   fi


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8378836](https://bugs.openjdk.org/browse/JDK-8378836) needs maintainer approval

### Issue
 * [JDK-8378836](https://bugs.openjdk.org/browse/JDK-8378836): Enable linktime-gc by default on Linux ppc64le (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/129/head:pull/129` \
`$ git checkout pull/129`

Update a local copy of the PR: \
`$ git checkout pull/129` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 129`

View PR using the GUI difftool: \
`$ git pr show -t 129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/129.diff">https://git.openjdk.org/jdk26u/pull/129.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/129#issuecomment-4118742759)
</details>
