### PR TITLE
8380663: Update jcmd man page to include AOT.end_recording diagnostic command

### DIFF
--- a/src/jdk.jcmd/share/man/jcmd.md
+++ b/src/jdk.jcmd/share/man/jcmd.md
@@ -134,6 +134,16 @@ The following commands are available:
 
     -   `-all`: (Optional) Show help for all commands (BOOLEAN, false) .
 
+`AOT.end_recording`
+:   Ends an in-progress AOT training and records the results to the file(s) specified by `-XX:AOTConfiguration` and/or `-XX:AOTCacheOutput`.
+
+    Impact: Low
+
+    **Note:**
+
+    The JVM must be started in AOT training mode using command-line arguments such as `-XX:AOTMode=record` or `-XX:AOTCacheOutput=<file>`.
+    The results of the AOT training can be an AOT configuration file, an AOT cache file, or both.
+
 `Compiler.CodeHeap_Analytics`  \[*function*\] \[*granularity*\]
 :   Print CodeHeap analytics
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8380663](https://bugs.openjdk.org/browse/JDK-8380663) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8380663](https://bugs.openjdk.org/browse/JDK-8380663): Update jcmd man page to include AOT.end_recording diagnostic command (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/134/head:pull/134` \
`$ git checkout pull/134`

Update a local copy of the PR: \
`$ git checkout pull/134` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 134`

View PR using the GUI difftool: \
`$ git pr show -t 134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/134.diff">https://git.openjdk.org/jdk26u/pull/134.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/134#issuecomment-4128511321)
</details>
