### PR TITLE
8375010: C2 VectorAPI: assert(vbox->is_CheckCastPP()) failed: should be expanded

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/VectorBoxExpandPhi.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorBoxExpandPhi.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import jdk.incubator.vector.*;
+
+/*
+ * @test
+ * @bug 8374903
+ * @summary C2 crashes when VectorBox Phi and vector Phi have different regions
+ * @modules jdk.incubator.vector
+ * @library /test/lib
+ *
+ * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,compiler.vectorapi.VectorBoxExpandPhi::test compiler.vectorapi.VectorBoxExpandPhi
+ */
+public class VectorBoxExpandPhi {
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; i++) {
+            test();
+        }
+    }
+
+    public static Object test() {
+        var v0 = DoubleVector.broadcast(DoubleVector.SPECIES_128, 1.0);
+        var v1 = (FloatVector)v0.convertShape(VectorOperators.Conversion.ofCast(double.class, float.class), FloatVector.SPECIES_64, 0);
+        var v2 = (FloatVector)v1.convertShape(VectorOperators.Conversion.ofReinterpret(float.class, float.class), FloatVector.SPECIES_64, 0);
+        return v2;
+    }
+}

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorBoxExpandProj.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorBoxExpandProj.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import jdk.incubator.vector.*;
+
+/*
+ * @test
+ * @bug 8375010
+ * @summary C2 crashes when expanding VectorBox with Proj input from vector math call
+ * @modules jdk.incubator.vector
+ * @library /test/lib
+ *
+ * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,compiler.vectorapi.VectorBoxExpandProj::test compiler.vectorapi.VectorBoxExpandProj
+ */
+public class VectorBoxExpandProj {
+    static boolean b;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            b = !b;
+            test();
+        }
+        System.out.println("PASS");
+    }
+
+    // TAN returns Proj (not VectorNode). Phi merging creates VectorBox(Phi, Proj).
+    // expand_vbox_node_helper must handle Proj inputs with vector type.
+    static Object test() {
+        var t = DoubleVector.broadcast(DoubleVector.SPECIES_128, 1.0).lanewise(VectorOperators.TAN);
+        return b ? t.convertShape(VectorOperators.Conversion.ofCast(double.class, double.class), DoubleVector.SPECIES_128, 0) : t;
+    }
+}


### PR DESCRIPTION
This is a backport of [JDK-8375010](https://bugs.openjdk.org/browse/JDK-8375010)

The check `vect->is_Vector() || vect->is_LoadVector()` in `expand_vbox_node_helper` does not handle `Proj` nodes that resolve to vector types, causing an assertion failure when such nodes flow through a `Phi` into `VectorBox`. The fix handles these two additional cases (VectorBox inside a `Phi` or `Proj` node), preventing the assert crash.

Tested: VectorBoxExpandPhi.java and `VectorBoxExpandProj.java` pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8374903](https://bugs.openjdk.org/browse/JDK-8374903) needs maintainer approval
- [x] [JDK-8375010](https://bugs.openjdk.org/browse/JDK-8375010) needs maintainer approval

### Issues
 * [JDK-8375010](https://bugs.openjdk.org/browse/JDK-8375010): C2 VectorAPI: assert(vbox-&gt;is_CheckCastPP()) failed: should be expanded (**Bug** - P3 - Approved)
 * [JDK-8374903](https://bugs.openjdk.org/browse/JDK-8374903): C2 VectorAPI: assert(vbox-&gt;as_Phi()-&gt;region() == vect-&gt;as_Phi()-&gt;region()) failed (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/136/head:pull/136` \
`$ git checkout pull/136`

Update a local copy of the PR: \
`$ git checkout pull/136` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/136/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 136`

View PR using the GUI difftool: \
`$ git pr show -t 136`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/136.diff">https://git.openjdk.org/jdk26u/pull/136.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/136#issuecomment-4138843768)
</details>
