### PR TITLE
8359433: The final modifier on Windows L&F internal UI classes prevents extending them in apps

### DIFF
--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsBorders.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsBorders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,7 +115,7 @@ public final class WindowsBorders {
     }
 
     @SuppressWarnings("serial") // Superclass is not serializable across versions
-    public static final class ProgressBarBorder extends AbstractBorder implements UIResource {
+    public static class ProgressBarBorder extends AbstractBorder implements UIResource {
         protected Color shadow;
         protected Color highlight;
 
@@ -148,7 +148,7 @@ public final class WindowsBorders {
      * @since 1.4
      */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
-    public static final class ToolBarBorder extends AbstractBorder implements UIResource, SwingConstants {
+    public static class ToolBarBorder extends AbstractBorder implements UIResource, SwingConstants {
         protected Color shadow;
         protected Color highlight;
 
@@ -308,7 +308,7 @@ public final class WindowsBorders {
      * @since 1.4
      */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
-    public static final class InternalFrameLineBorder extends LineBorder implements
+    public static class InternalFrameLineBorder extends LineBorder implements
             UIResource {
         protected Color activeColor;
         protected Color inactiveColor;

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsButtonUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsButtonUI.java
@@ -58,7 +58,7 @@ import static com.sun.java.swing.plaf.windows.XPStyle.Skin;
  *
  * @author Jeff Dinkins
  */
-public final class WindowsButtonUI extends BasicButtonUI
+public class WindowsButtonUI extends BasicButtonUI
 {
     protected int dashedRectGapX;
     protected int dashedRectGapY;

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsCheckBoxMenuItemUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsCheckBoxMenuItemUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ import com.sun.java.swing.plaf.windows.TMSchema.State;
 /**
  * Windows check box menu item.
  */
-public final class WindowsCheckBoxMenuItemUI extends BasicCheckBoxMenuItemUI {
+public class WindowsCheckBoxMenuItemUI extends BasicCheckBoxMenuItemUI {
 
     final WindowsMenuItemUIAccessor accessor =
         new WindowsMenuItemUIAccessor() {

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsCheckBoxUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsCheckBoxUI.java
@@ -37,7 +37,7 @@ import sun.awt.AppContext;
  *
  * @author Jeff Dinkins
  */
-public final class WindowsCheckBoxUI extends WindowsRadioButtonUI
+public class WindowsCheckBoxUI extends WindowsRadioButtonUI
 {
     // NOTE: WindowsCheckBoxUI inherits from WindowsRadioButtonUI instead
     // of BasicCheckBoxUI because we want to pick up all the

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsClassicLookAndFeel.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsClassicLookAndFeel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ package com.sun.java.swing.plaf.windows;
  * @since 1.5
  */
 @SuppressWarnings("serial") // Superclass is not serializable across versions
-public final class WindowsClassicLookAndFeel extends WindowsLookAndFeel {
+public class WindowsClassicLookAndFeel extends WindowsLookAndFeel {
     @Override
     public String getName() {
         return "Windows Classic";

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsComboBoxUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsComboBoxUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,7 @@ import static com.sun.java.swing.plaf.windows.XPStyle.Skin;
  * @author Tom Santos
  * @author Igor Kushnirskiy
  */
-public final class WindowsComboBoxUI extends BasicComboBoxUI {
+public class WindowsComboBoxUI extends BasicComboBoxUI {
 
     private static final MouseListener rolloverListener =
         new MouseAdapter() {
@@ -532,7 +532,7 @@ public final class WindowsComboBoxUI extends BasicComboBoxUI {
     }
 
     @SuppressWarnings("serial") // Same-version serialization only
-    protected final class WinComboPopUp extends BasicComboPopup {
+    protected class WinComboPopUp extends BasicComboPopup {
         private Skin listBoxBorder = null;
         private XPStyle xp;
 
@@ -550,7 +550,7 @@ public final class WindowsComboBoxUI extends BasicComboBoxUI {
             return new InvocationKeyHandler();
         }
 
-        protected final class InvocationKeyHandler extends BasicComboPopup.InvocationKeyHandler {
+        protected class InvocationKeyHandler extends BasicComboPopup.InvocationKeyHandler {
             protected InvocationKeyHandler() {
                 WinComboPopUp.this.super();
             }
@@ -570,7 +570,7 @@ public final class WindowsComboBoxUI extends BasicComboBoxUI {
     /**
      * Subclassed to highlight selected item in an editable combo box.
      */
-    public static final class WindowsComboBoxEditor
+    public static class WindowsComboBoxEditor
         extends BasicComboBoxEditor.UIResource {
 
         /**

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsDesktopIconUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsDesktopIconUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javax.swing.plaf.basic.BasicDesktopIconUI;
 /**
  * Windows icon for a minimized window on the desktop.
  */
-public final class WindowsDesktopIconUI extends BasicDesktopIconUI {
+public class WindowsDesktopIconUI extends BasicDesktopIconUI {
     private int width;
 
     public static ComponentUI createUI(JComponent c) {

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsDesktopManager.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsDesktopManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ import java.lang.ref.WeakReference;
  * @author Thomas Ball
  */
 @SuppressWarnings("serial") // JDK-implementation class
-public final class WindowsDesktopManager extends DefaultDesktopManager
+public class WindowsDesktopManager extends DefaultDesktopManager
         implements java.io.Serializable, javax.swing.plaf.UIResource {
 
     /* The frame which is currently selected/activated.

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsDesktopPaneUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsDesktopPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import javax.swing.plaf.basic.BasicDesktopPaneUI;
  *
  * @author David Kloba
  */
-public final class WindowsDesktopPaneUI extends BasicDesktopPaneUI
+public class WindowsDesktopPaneUI extends BasicDesktopPaneUI
 {
     public static ComponentUI createUI(JComponent c) {
         return new WindowsDesktopPaneUI();

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsEditorPaneUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsEditorPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import javax.swing.text.Caret;
 /**
  * Windows rendition of the component.
  */
-public final class WindowsEditorPaneUI extends BasicEditorPaneUI
+public class WindowsEditorPaneUI extends BasicEditorPaneUI
 {
 
     /**

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsFileChooserUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsFileChooserUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,7 +101,7 @@ import sun.swing.WindowsPlacesBar;
  *
  * @author Jeff Dinkins
  */
-public final class WindowsFileChooserUI extends BasicFileChooserUI {
+public class WindowsFileChooserUI extends BasicFileChooserUI {
 
     // The following are private because the implementation of the
     // Windows FileChooser L&F is not complete yet.
@@ -1122,7 +1122,7 @@ public final class WindowsFileChooserUI extends BasicFileChooserUI {
      * Data model for a type-face selection combo-box.
      */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
-    protected final class DirectoryComboBoxModel extends AbstractListModel<File> implements ComboBoxModel<File> {
+    protected class DirectoryComboBoxModel extends AbstractListModel<File> implements ComboBoxModel<File> {
         Vector<File> directories = new Vector<File>();
         int[] depths = null;
         File selectedDirectory = null;
@@ -1252,7 +1252,7 @@ public final class WindowsFileChooserUI extends BasicFileChooserUI {
      * Render different type sizes and styles.
      */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
-    public final class FilterComboBoxRenderer extends DefaultListCellRenderer {
+    public class FilterComboBoxRenderer extends DefaultListCellRenderer {
         @Override
         public Component getListCellRendererComponent(JList<?> list,
             Object value, int index, boolean isSelected,
@@ -1279,7 +1279,7 @@ public final class WindowsFileChooserUI extends BasicFileChooserUI {
      * Data model for a type-face selection combo-box.
      */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
-    protected final class FilterComboBoxModel extends AbstractListModel<FileFilter> implements ComboBoxModel<FileFilter>,
+    protected class FilterComboBoxModel extends AbstractListModel<FileFilter> implements ComboBoxModel<FileFilter>,
             PropertyChangeListener {
         protected FileFilter[] filters;
         protected FilterComboBoxModel() {
@@ -1362,7 +1362,7 @@ public final class WindowsFileChooserUI extends BasicFileChooserUI {
     /**
      * Acts when DirectoryComboBox has changed the selected item.
      */
-    protected final class DirectoryComboBoxAction implements ActionListener {
+    protected class DirectoryComboBoxAction implements ActionListener {
 
 
 
@@ -1387,7 +1387,7 @@ public final class WindowsFileChooserUI extends BasicFileChooserUI {
     // ***********************
     // * FileView operations *
     // ***********************
-    protected final class WindowsFileView extends BasicFileView {
+    protected class WindowsFileView extends BasicFileView {
         /* FileView type descriptions */
 
         @Override

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsInternalFrameTitlePane.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsInternalFrameTitlePane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -418,7 +418,7 @@ public class WindowsInternalFrameTitlePane extends BasicInternalFrameTitlePane {
         return new WindowsTitlePaneLayout();
     }
 
-    public final class WindowsTitlePaneLayout extends BasicInternalFrameTitlePane.TitlePaneLayout {
+    public class WindowsTitlePaneLayout extends BasicInternalFrameTitlePane.TitlePaneLayout {
         private Insets captionMargin = null;
         private Insets contentMargin = null;
         private XPStyle xp = XPStyle.getXP();
@@ -506,7 +506,7 @@ public class WindowsInternalFrameTitlePane extends BasicInternalFrameTitlePane {
         }
     } // end WindowsTitlePaneLayout
 
-    public final class WindowsPropertyChangeHandler extends PropertyChangeHandler {
+    public class WindowsPropertyChangeHandler extends PropertyChangeHandler {
         @Override
         public void propertyChange(PropertyChangeEvent evt) {
             String prop = evt.getPropertyName();
@@ -530,7 +530,7 @@ public class WindowsInternalFrameTitlePane extends BasicInternalFrameTitlePane {
      * <p>
      * Note: We assume here that icons are square.
      */
-    public static final class ScalableIconUIResource implements Icon, UIResource {
+    public static class ScalableIconUIResource implements Icon, UIResource {
         // We can use an arbitrary size here because we scale to it in paintIcon()
         private static final int SIZE = 16;
 

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsInternalFrameUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsInternalFrameUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ import static com.sun.java.swing.plaf.windows.XPStyle.Skin;
 /**
  * Windows rendition of the component.
  */
-public final class WindowsInternalFrameUI extends BasicInternalFrameUI
+public class WindowsInternalFrameUI extends BasicInternalFrameUI
 {
     XPStyle xp = XPStyle.getXP();
 

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsLabelUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsLabelUI.java
@@ -41,7 +41,7 @@ import sun.swing.SwingUtilities2;
 /**
  * Windows rendition of the component.
  */
-public final class WindowsLabelUI extends BasicLabelUI {
+public class WindowsLabelUI extends BasicLabelUI {
 
     private static final Object WINDOWS_LABEL_UI_KEY = new Object();
 

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuBarUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuBarUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ import sun.swing.MnemonicHandler;
 /**
  * Windows rendition of the component.
  */
-public final class WindowsMenuBarUI extends BasicMenuBarUI
+public class WindowsMenuBarUI extends BasicMenuBarUI
 {
     /* to be accessed on the EDT only */
     private WindowListener windowListener = null;

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuItemUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuItemUI.java
@@ -58,7 +58,7 @@ import sun.swing.SwingUtilities2;
  *
  * @author Igor Kushnirskiy
  */
-public final class WindowsMenuItemUI extends BasicMenuItemUI {
+public class WindowsMenuItemUI extends BasicMenuItemUI {
     /**
      * The instance of {@code PropertyChangeListener}.
      */

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ import com.sun.java.swing.plaf.windows.TMSchema.State;
 /**
  * Windows rendition of the component.
  */
-public final class WindowsMenuUI extends BasicMenuUI {
+public class WindowsMenuUI extends BasicMenuUI {
     protected Integer menuBarHeight;
     protected boolean hotTrackingOn;
 
@@ -283,7 +283,7 @@ public final class WindowsMenuUI extends BasicMenuUI {
      * true when the mouse enters the menu and false when it exits.
      * @since 1.4
      */
-    protected final class WindowsMouseInputHandler extends BasicMenuUI.MouseInputHandler {
+    protected class WindowsMouseInputHandler extends BasicMenuUI.MouseInputHandler {
         @Override
         public void mouseEntered(MouseEvent evt) {
             super.mouseEntered(evt);

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsOptionPaneUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsOptionPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,5 +30,5 @@ import javax.swing.plaf.basic.BasicOptionPaneUI;
 /**
  * Windows rendition of the component.
  */
-public final class WindowsOptionPaneUI extends BasicOptionPaneUI {
+public class WindowsOptionPaneUI extends BasicOptionPaneUI {
 }

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsPasswordFieldUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsPasswordFieldUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import javax.swing.text.Caret;
 /**
  * Windows rendition of the component.
  */
-public final class WindowsPasswordFieldUI extends BasicPasswordFieldUI {
+public class WindowsPasswordFieldUI extends BasicPasswordFieldUI {
 
     /**
      * Creates a UI for a JPasswordField

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsPopupMenuSeparatorUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsPopupMenuSeparatorUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ import com.sun.java.swing.plaf.windows.XPStyle.Skin;
  * @author Igor Kushnirskiy
  */
 
-public final class WindowsPopupMenuSeparatorUI extends BasicPopupMenuSeparatorUI {
+public class WindowsPopupMenuSeparatorUI extends BasicPopupMenuSeparatorUI {
 
     public static ComponentUI createUI(JComponent c) {
         return new WindowsPopupMenuSeparatorUI();

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsPopupMenuUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsPopupMenuUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ import static sun.swing.SwingUtilities2.BASICMENUITEMUI_MAX_TEXT_OFFSET;
  *
  * @author Igor Kushnirskiy
  */
-public final class WindowsPopupMenuUI extends BasicPopupMenuUI {
+public class WindowsPopupMenuUI extends BasicPopupMenuUI {
 
     static MnemonicListener mnemonicListener = null;
     static final Object GUTTER_OFFSET_KEY =

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsProgressBarUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsProgressBarUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ import static com.sun.java.swing.plaf.windows.XPStyle.Skin;
  *
  * @author Michael C. Albers
  */
-public final class WindowsProgressBarUI extends BasicProgressBarUI
+public class WindowsProgressBarUI extends BasicProgressBarUI
 {
 
     private Rectangle previousFullBox;

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsRadioButtonMenuItemUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsRadioButtonMenuItemUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ import com.sun.java.swing.plaf.windows.TMSchema.State;
 /**
  * Windows rendition of the component.
  */
-public final class WindowsRadioButtonMenuItemUI extends BasicRadioButtonMenuItemUI {
+public class WindowsRadioButtonMenuItemUI extends BasicRadioButtonMenuItemUI {
 
     final WindowsMenuItemUIAccessor accessor =
         new WindowsMenuItemUIAccessor() {

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsRootPaneUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsRootPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,7 +70,7 @@ import sun.swing.MnemonicHandler;
  * @author Mark Davidson
  * @since 1.4
  */
-public final class WindowsRootPaneUI extends BasicRootPaneUI {
+public class WindowsRootPaneUI extends BasicRootPaneUI {
 
     private static final WindowsRootPaneUI windowsRootPaneUI = new WindowsRootPaneUI();
     static final AltProcessor altProcessor = new AltProcessor();

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsScrollBarUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsScrollBarUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ import static com.sun.java.swing.plaf.windows.XPStyle.Skin;
 /**
  * Windows rendition of the component.
  */
-public final class WindowsScrollBarUI extends BasicScrollBarUI {
+public class WindowsScrollBarUI extends BasicScrollBarUI {
     private Grid thumbGrid;
     private Grid highlightGrid;
     private Dimension horizontalThumbSize;

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsScrollPaneUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsScrollPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,5 +30,5 @@ import javax.swing.plaf.basic.BasicScrollPaneUI;
 /**
  * Windows rendition of the component.
  */
-public final class WindowsScrollPaneUI extends BasicScrollPaneUI
+public class WindowsScrollPaneUI extends BasicScrollPaneUI
 {}

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsSeparatorUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsSeparatorUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,4 +30,4 @@ import javax.swing.plaf.basic.*;
 /**
  * Windows Separator.
  */
-public final class WindowsSeparatorUI extends BasicSeparatorUI { }
+public class WindowsSeparatorUI extends BasicSeparatorUI { }

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsSliderUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsSliderUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ import static com.sun.java.swing.plaf.windows.XPStyle.Skin;
 /**
  * Windows rendition of the component.
  */
-public final class WindowsSliderUI extends BasicSliderUI
+public class WindowsSliderUI extends BasicSliderUI
 {
     private boolean rollover = false;
     private boolean pressed = false;

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsSpinnerUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsSpinnerUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import static com.sun.java.swing.plaf.windows.TMSchema.State;
 import static com.sun.java.swing.plaf.windows.XPStyle.Skin;
 
 
-public final class WindowsSpinnerUI extends BasicSpinnerUI {
+public class WindowsSpinnerUI extends BasicSpinnerUI {
     public static ComponentUI createUI(JComponent c) {
         return new WindowsSpinnerUI();
     }

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsSplitPaneDivider.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsSplitPaneDivider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import javax.swing.plaf.basic.BasicSplitPaneUI;
  * @author Jeff Dinkins
  */
 @SuppressWarnings("serial") // Superclass is not serializable across versions
-public final class WindowsSplitPaneDivider extends BasicSplitPaneDivider
+public class WindowsSplitPaneDivider extends BasicSplitPaneDivider
 {
 
     /**

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsSplitPaneUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsSplitPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import javax.swing.plaf.basic.BasicSplitPaneUI;
 /**
  * Windows rendition of the component.
  */
-public final class WindowsSplitPaneUI extends BasicSplitPaneUI
+public class WindowsSplitPaneUI extends BasicSplitPaneUI
 {
 
     public WindowsSplitPaneUI() {

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsTabbedPaneUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsTabbedPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ import static com.sun.java.swing.plaf.windows.XPStyle.Skin;
 /**
  * Windows rendition of the component.
  */
-public final class WindowsTabbedPaneUI extends BasicTabbedPaneUI {
+public class WindowsTabbedPaneUI extends BasicTabbedPaneUI {
     /**
      * Keys to use for forward focus traversal when the JComponent is
      * managing focus.

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsTableHeaderUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsTableHeaderUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ import static com.sun.java.swing.plaf.windows.TMSchema.Part;
 import static com.sun.java.swing.plaf.windows.TMSchema.State;
 import static com.sun.java.swing.plaf.windows.XPStyle.Skin;
 
-public final class WindowsTableHeaderUI extends BasicTableHeaderUI {
+public class WindowsTableHeaderUI extends BasicTableHeaderUI {
     private TableCellRenderer originalHeaderRenderer;
 
     public static ComponentUI createUI(JComponent h) {

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsTextAreaUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsTextAreaUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import javax.swing.text.Caret;
 /**
  * Windows rendition of the component.
  */
-public final class WindowsTextAreaUI extends BasicTextAreaUI {
+public class WindowsTextAreaUI extends BasicTextAreaUI {
     /**
      * Creates the object to use for a caret.  By default an
      * instance of WindowsCaret is created.  This method

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsTextFieldUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsTextFieldUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ import javax.swing.text.Position;
  *
  * @author  Timothy Prinzing
  */
-public final class WindowsTextFieldUI extends BasicTextFieldUI
+public class WindowsTextFieldUI extends BasicTextFieldUI
 {
     /**
      * Creates a UI for a JTextField.

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsTextPaneUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsTextPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import javax.swing.text.Caret;
 /**
  * Windows rendition of the component.
  */
-public final class WindowsTextPaneUI extends BasicTextPaneUI
+public class WindowsTextPaneUI extends BasicTextPaneUI
 {
     /**
      * Creates a UI for a JTextPane.

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsToggleButtonUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsToggleButtonUI.java
@@ -45,7 +45,7 @@ import sun.awt.AppContext;
  *
  * @author Jeff Dinkins
  */
-public final class WindowsToggleButtonUI extends BasicToggleButtonUI
+public class WindowsToggleButtonUI extends BasicToggleButtonUI
 {
     protected int dashedRectGapX;
     protected int dashedRectGapY;

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsToolBarSeparatorUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsToolBarSeparatorUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import static com.sun.java.swing.plaf.windows.XPStyle.Skin;
  *
  * @author Mark Davidson
  */
-public final class WindowsToolBarSeparatorUI extends BasicToolBarSeparatorUI {
+public class WindowsToolBarSeparatorUI extends BasicToolBarSeparatorUI {
 
     public static ComponentUI createUI( JComponent c ) {
         return new WindowsToolBarSeparatorUI();

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsToolBarUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsToolBarUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ import javax.swing.plaf.basic.BasicToolBarUI;
 import static com.sun.java.swing.plaf.windows.TMSchema.Part;
 
 
-public final class WindowsToolBarUI extends BasicToolBarUI {
+public class WindowsToolBarUI extends BasicToolBarUI {
 
     public static ComponentUI createUI(JComponent c) {
         return new WindowsToolBarUI();

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsTreeUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsTreeUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -167,7 +167,7 @@ public class WindowsTreeUI extends BasicTreeUI {
      * The plus sign button icon
      */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
-    public static final class CollapsedIcon extends ExpandedIcon {
+    public static class CollapsedIcon extends ExpandedIcon {
         public static Icon createCollapsedIcon() {
             return new CollapsedIcon();
         }
@@ -185,7 +185,7 @@ public class WindowsTreeUI extends BasicTreeUI {
     }
 
     @SuppressWarnings("serial") // Superclass is not serializable across versions
-    public final class WindowsTreeCellRenderer extends DefaultTreeCellRenderer {
+    public class WindowsTreeCellRenderer extends DefaultTreeCellRenderer {
 
         /**
          * Configures the renderer based on the passed in components.

--- a/test/jdk/javax/swing/plaf/windows/bug4991587.java
+++ b/test/jdk/javax/swing/plaf/windows/bug4991587.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4991587
+ * @bug 4991587 8359433
  * @requires (os.family == "windows")
  * @summary Tests that disabled JButton text is positioned properly in Windows L&F
  * @modules java.desktop/com.sun.java.swing.plaf.windows


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [4d262375](https://github.com/openjdk/jdk/commit/4d2623757fbe8c9fa8c22817a993ca85a2403873) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 26 Mar 2026 and was reviewed by Phil Race and Alexey Ivanov.

The change is mostly clean, except for the copyright years.

Thanks!


The reason for the fix (copied from [mainline](https://github.com/openjdk/jdk/pull/30170)):
>[JDK-8352638](https://bugs.openjdk.org/browse/JDK-8352638) added final to public classes in java.desktop/windows including the Windows L&F package as a code consistency cleanup. This breaks applications that extend UI classes and they get IncompatibleClassChangeError at runtime.

>Although this package is not part of the public API, we decided to remove the final modifier from all public and protected classes, as well as their inner classes in com.sun.java.swing.plaf.windows. Package-private classes, private inner classes, and the `@Override `annotations introduced by JDK-8352638 remain unchanged.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8359433](https://bugs.openjdk.org/browse/JDK-8359433) needs maintainer approval

### Issue
 * [JDK-8359433](https://bugs.openjdk.org/browse/JDK-8359433): The final modifier on Windows L&amp;F internal UI classes prevents extending them in apps (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/137/head:pull/137` \
`$ git checkout pull/137`

Update a local copy of the PR: \
`$ git checkout pull/137` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 137`

View PR using the GUI difftool: \
`$ git pr show -t 137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/137.diff">https://git.openjdk.org/jdk26u/pull/137.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/137#issuecomment-4139378468)
</details>
