### PR TITLE
8374343: Fix SIGSEGV when lib/modules is unreadable

### DIFF
--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -1418,6 +1418,10 @@ char* ClassLoader::lookup_vm_options() {
   jio_snprintf(modules_path, JVM_MAXPATHLEN, "%s%slib%smodules", Arguments::get_java_home(), fileSep, fileSep);
   JImage_file =(*JImageOpen)(modules_path, &error);
   if (JImage_file == nullptr) {
+    if (Arguments::has_jimage()) {
+      // The modules file exists but is unreadable or corrupt
+      vm_exit_during_initialization(err_msg("Unable to load %s", modules_path));
+    }
     return nullptr;
   }
 


### PR DESCRIPTION
This pull request contains a backport of commit [48846744](https://github.com/openjdk/jdk/commit/48846744ca96ce3c6464a1a440b9e46119dfbb88) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The simple change fixes SIGSEGV crash during startup if the runtime image (lib/modules) exists but is unreadable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8374343](https://bugs.openjdk.org/browse/JDK-8374343) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8374343](https://bugs.openjdk.org/browse/JDK-8374343): Fix SIGSEGV when lib/modules is unreadable (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/139/head:pull/139` \
`$ git checkout pull/139`

Update a local copy of the PR: \
`$ git checkout pull/139` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 139`

View PR using the GUI difftool: \
`$ git pr show -t 139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/139.diff">https://git.openjdk.org/jdk26u/pull/139.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/139#issuecomment-4142806711)
</details>
