### PR TITLE
8375294: (fs) Files.copy can fail with EOPNOTSUPP when copy_file_range not supported

### DIFF
--- a/src/java.base/linux/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/linux/native/libnio/ch/FileDispatcherImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ Java_sun_nio_ch_FileDispatcherImpl_transferFrom0(JNIEnv *env, jobject this,
     if (n < 0) {
         if (errno == EAGAIN)
             return IOS_UNAVAILABLE;
-        if (errno == ENOSYS)
+        if (errno == ENOSYS || errno == EOPNOTSUPP)
             return IOS_UNSUPPORTED_CASE;
         if ((errno == EBADF || errno == EINVAL || errno == EXDEV) &&
             ((ssize_t)count >= 0))
@@ -103,6 +103,7 @@ Java_sun_nio_ch_FileDispatcherImpl_transferTo0(JNIEnv *env, jobject this,
                 case EINVAL:
                 case ENOSYS:
                 case EXDEV:
+                case EOPNOTSUPP:
                     // ignore and try sendfile()
                     break;
                 default:

--- a/src/java.base/linux/native/libnio/fs/LinuxNativeDispatcher.c
+++ b/src/java.base/linux/native/libnio/fs/LinuxNativeDispatcher.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -193,6 +193,7 @@ Java_sun_nio_fs_LinuxNativeDispatcher_directCopy0
                     case EINVAL:
                     case ENOSYS:
                     case EXDEV:
+                    case EOPNOTSUPP:
                         // ignore and try sendfile()
                         break;
                     default:


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8375294](https://bugs.openjdk.org/browse/JDK-8375294) needs maintainer approval

### Issue
 * [JDK-8375294](https://bugs.openjdk.org/browse/JDK-8375294): (fs) Files.copy can fail with EOPNOTSUPP when copy_file_range not supported (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/146/head:pull/146` \
`$ git checkout pull/146`

Update a local copy of the PR: \
`$ git checkout pull/146` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 146`

View PR using the GUI difftool: \
`$ git pr show -t 146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/146.diff">https://git.openjdk.org/jdk26u/pull/146.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/146#issuecomment-4170513185)
</details>
