### PR TITLE
8368977: Provide clear naming for AVX10 identifiers

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -449,8 +449,8 @@ const int FPUStateSizeInWords = 2688 / wordSize;
 // imm8[1:0]                =  00 (min) / 01 (max)
 //
 // [1] https://www.intel.com/content/www/us/en/content-details/856721/intel-advanced-vector-extensions-10-2-intel-avx10-2-architecture-specification.html?wapkw=AVX10
-const int AVX10_MINMAX_MAX_COMPARE_SIGN = 0x5;
-const int AVX10_MINMAX_MIN_COMPARE_SIGN = 0x4;
+const int AVX10_2_MINMAX_MAX_COMPARE_SIGN = 0x5;
+const int AVX10_2_MINMAX_MIN_COMPARE_SIGN = 0x4;
 
 // The Intel x86/Amd64 Assembler: Pure assembler doing NO optimizations on the instruction
 // level (e.g. mov rax, 0 is not translated into xor rax, rax!); i.e., what you write

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -1033,8 +1033,8 @@ void C2_MacroAssembler::vminmax_fp(int opc, BasicType elem_bt, XMMRegister dst, 
   assert(opc == Op_MinV || opc == Op_MinReductionV ||
          opc == Op_MaxV || opc == Op_MaxReductionV, "sanity");
 
-  int imm8 = (opc == Op_MinV || opc == Op_MinReductionV) ? AVX10_MINMAX_MIN_COMPARE_SIGN
-                                                         : AVX10_MINMAX_MAX_COMPARE_SIGN;
+  int imm8 = (opc == Op_MinV || opc == Op_MinReductionV) ? AVX10_2_MINMAX_MIN_COMPARE_SIGN
+                                                         : AVX10_2_MINMAX_MAX_COMPARE_SIGN;
   if (elem_bt == T_FLOAT) {
     evminmaxps(dst, mask, src1, src2, true, imm8, vlen_enc);
   } else {
@@ -5163,7 +5163,7 @@ void C2_MacroAssembler::vector_castD2X_evex(BasicType to_elem_bt, XMMRegister ds
   }
 }
 
-void C2_MacroAssembler::vector_castF2X_avx10(BasicType to_elem_bt, XMMRegister dst, XMMRegister src, int vec_enc) {
+void C2_MacroAssembler::vector_castF2X_avx10_2(BasicType to_elem_bt, XMMRegister dst, XMMRegister src, int vec_enc) {
   switch(to_elem_bt) {
     case T_LONG:
       evcvttps2qqs(dst, src, vec_enc);
@@ -5183,7 +5183,7 @@ void C2_MacroAssembler::vector_castF2X_avx10(BasicType to_elem_bt, XMMRegister d
   }
 }
 
-void C2_MacroAssembler::vector_castF2X_avx10(BasicType to_elem_bt, XMMRegister dst, Address src, int vec_enc) {
+void C2_MacroAssembler::vector_castF2X_avx10_2(BasicType to_elem_bt, XMMRegister dst, Address src, int vec_enc) {
   switch(to_elem_bt) {
     case T_LONG:
       evcvttps2qqs(dst, src, vec_enc);
@@ -5203,7 +5203,7 @@ void C2_MacroAssembler::vector_castF2X_avx10(BasicType to_elem_bt, XMMRegister d
   }
 }
 
-void C2_MacroAssembler::vector_castD2X_avx10(BasicType to_elem_bt, XMMRegister dst, XMMRegister src, int vec_enc) {
+void C2_MacroAssembler::vector_castD2X_avx10_2(BasicType to_elem_bt, XMMRegister dst, XMMRegister src, int vec_enc) {
   switch(to_elem_bt) {
     case T_LONG:
       evcvttpd2qqs(dst, src, vec_enc);
@@ -5223,7 +5223,7 @@ void C2_MacroAssembler::vector_castD2X_avx10(BasicType to_elem_bt, XMMRegister d
   }
 }
 
-void C2_MacroAssembler::vector_castD2X_avx10(BasicType to_elem_bt, XMMRegister dst, Address src, int vec_enc) {
+void C2_MacroAssembler::vector_castD2X_avx10_2(BasicType to_elem_bt, XMMRegister dst, Address src, int vec_enc) {
   switch(to_elem_bt) {
     case T_LONG:
       evcvttpd2qqs(dst, src, vec_enc);

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -347,13 +347,13 @@ public:
                           XMMRegister xtmp2, XMMRegister xtmp3, XMMRegister xtmp4, XMMRegister xtmp5,
                           AddressLiteral float_sign_flip, Register rscratch, int vec_enc);
 
-  void vector_castF2X_avx10(BasicType to_elem_bt, XMMRegister dst, XMMRegister src, int vec_enc);
+  void vector_castF2X_avx10_2(BasicType to_elem_bt, XMMRegister dst, XMMRegister src, int vec_enc);
 
-  void vector_castF2X_avx10(BasicType to_elem_bt, XMMRegister dst, Address src, int vec_enc);
+  void vector_castF2X_avx10_2(BasicType to_elem_bt, XMMRegister dst, Address src, int vec_enc);
 
-  void vector_castD2X_avx10(BasicType to_elem_bt, XMMRegister dst, XMMRegister src, int vec_enc);
+  void vector_castD2X_avx10_2(BasicType to_elem_bt, XMMRegister dst, XMMRegister src, int vec_enc);
 
-  void vector_castD2X_avx10(BasicType to_elem_bt, XMMRegister dst, Address src, int vec_enc);
+  void vector_castD2X_avx10_2(BasicType to_elem_bt, XMMRegister dst, Address src, int vec_enc);
 
   void vector_cast_double_to_int_special_cases_avx(XMMRegister dst, XMMRegister src, XMMRegister xtmp1, XMMRegister xtmp2,
                                                    XMMRegister xtmp3, XMMRegister xtmp4, XMMRegister xtmp5, Register rscratch,

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -8885,9 +8885,9 @@ void MacroAssembler::evpmins(BasicType type, XMMRegister dst, KRegister mask, XM
     case T_LONG:
       evpminsq(dst, mask, nds, src, merge, vector_len); break;
     case T_FLOAT:
-      evminmaxps(dst, mask, nds, src, merge, AVX10_MINMAX_MIN_COMPARE_SIGN, vector_len); break;
+      evminmaxps(dst, mask, nds, src, merge, AVX10_2_MINMAX_MIN_COMPARE_SIGN, vector_len); break;
     case T_DOUBLE:
-      evminmaxpd(dst, mask, nds, src, merge, AVX10_MINMAX_MIN_COMPARE_SIGN, vector_len); break;
+      evminmaxpd(dst, mask, nds, src, merge, AVX10_2_MINMAX_MIN_COMPARE_SIGN, vector_len); break;
     default:
       fatal("Unexpected type argument %s", type2name(type)); break;
   }
@@ -8904,9 +8904,9 @@ void MacroAssembler::evpmaxs(BasicType type, XMMRegister dst, KRegister mask, XM
     case T_LONG:
       evpmaxsq(dst, mask, nds, src, merge, vector_len); break;
     case T_FLOAT:
-      evminmaxps(dst, mask, nds, src, merge, AVX10_MINMAX_MAX_COMPARE_SIGN, vector_len); break;
+      evminmaxps(dst, mask, nds, src, merge, AVX10_2_MINMAX_MAX_COMPARE_SIGN, vector_len); break;
     case T_DOUBLE:
-      evminmaxpd(dst, mask, nds, src, merge, AVX10_MINMAX_MAX_COMPARE_SIGN, vector_len); break;
+      evminmaxpd(dst, mask, nds, src, merge, AVX10_2_MINMAX_MAX_COMPARE_SIGN, vector_len); break;
     default:
       fatal("Unexpected type argument %s", type2name(type)); break;
   }
@@ -8923,9 +8923,9 @@ void MacroAssembler::evpmins(BasicType type, XMMRegister dst, KRegister mask, XM
     case T_LONG:
       evpminsq(dst, mask, nds, src, merge, vector_len); break;
     case T_FLOAT:
-      evminmaxps(dst, mask, nds, src, merge, AVX10_MINMAX_MIN_COMPARE_SIGN, vector_len); break;
+      evminmaxps(dst, mask, nds, src, merge, AVX10_2_MINMAX_MIN_COMPARE_SIGN, vector_len); break;
     case T_DOUBLE:
-      evminmaxpd(dst, mask, nds, src, merge, AVX10_MINMAX_MIN_COMPARE_SIGN, vector_len); break;
+      evminmaxpd(dst, mask, nds, src, merge, AVX10_2_MINMAX_MIN_COMPARE_SIGN, vector_len); break;
     default:
       fatal("Unexpected type argument %s", type2name(type)); break;
   }
@@ -8942,9 +8942,9 @@ void MacroAssembler::evpmaxs(BasicType type, XMMRegister dst, KRegister mask, XM
     case T_LONG:
       evpmaxsq(dst, mask, nds, src, merge, vector_len); break;
     case T_FLOAT:
-      evminmaxps(dst, mask, nds, src, merge, AVX10_MINMAX_MAX_COMPARE_SIGN, vector_len); break;
+      evminmaxps(dst, mask, nds, src, merge, AVX10_2_MINMAX_MAX_COMPARE_SIGN, vector_len); break;
     case T_DOUBLE:
-      evminmaxps(dst, mask, nds, src, merge, AVX10_MINMAX_MAX_COMPARE_SIGN, vector_len); break;
+      evminmaxps(dst, mask, nds, src, merge, AVX10_2_MINMAX_MAX_COMPARE_SIGN, vector_len); break;
     default:
       fatal("Unexpected type argument %s", type2name(type)); break;
   }

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -7290,12 +7290,12 @@ instruct loadD(regD dst, memory mem)
 %}
 
 // max = java.lang.Math.max(float a, float b)
-instruct maxF_avx10_reg(regF dst, regF a, regF b) %{
+instruct maxF_reg_avx10_2(regF dst, regF a, regF b) %{
   predicate(VM_Version::supports_avx10_2());
   match(Set dst (MaxF a b));
   format %{ "maxF $dst, $a, $b" %}
   ins_encode %{
-    __ eminmaxss($dst$$XMMRegister, $a$$XMMRegister, $b$$XMMRegister, AVX10_MINMAX_MAX_COMPARE_SIGN);
+    __ eminmaxss($dst$$XMMRegister, $a$$XMMRegister, $b$$XMMRegister, AVX10_2_MINMAX_MAX_COMPARE_SIGN);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -7326,12 +7326,12 @@ instruct maxF_reduction_reg(legRegF dst, legRegF a, legRegF b, legRegF xtmp, rRe
 %}
 
 // max = java.lang.Math.max(double a, double b)
-instruct maxD_avx10_reg(regD dst, regD a, regD b) %{
+instruct maxD_reg_avx10_2(regD dst, regD a, regD b) %{
   predicate(VM_Version::supports_avx10_2());
   match(Set dst (MaxD a b));
   format %{ "maxD $dst, $a, $b" %}
   ins_encode %{
-    __ eminmaxsd($dst$$XMMRegister, $a$$XMMRegister, $b$$XMMRegister, AVX10_MINMAX_MAX_COMPARE_SIGN);
+    __ eminmaxsd($dst$$XMMRegister, $a$$XMMRegister, $b$$XMMRegister, AVX10_2_MINMAX_MAX_COMPARE_SIGN);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -7362,12 +7362,12 @@ instruct maxD_reduction_reg(legRegD dst, legRegD a, legRegD b, legRegD xtmp, rRe
 %}
 
 // max = java.lang.Math.min(float a, float b)
-instruct minF_avx10_reg(regF dst, regF a, regF b) %{
+instruct minF_reg_avx10_2(regF dst, regF a, regF b) %{
   predicate(VM_Version::supports_avx10_2());
   match(Set dst (MinF a b));
   format %{ "minF $dst, $a, $b" %}
   ins_encode %{
-    __ eminmaxss($dst$$XMMRegister, $a$$XMMRegister, $b$$XMMRegister, AVX10_MINMAX_MIN_COMPARE_SIGN);
+    __ eminmaxss($dst$$XMMRegister, $a$$XMMRegister, $b$$XMMRegister, AVX10_2_MINMAX_MIN_COMPARE_SIGN);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -7398,12 +7398,12 @@ instruct minF_reduction_reg(legRegF dst, legRegF a, legRegF b, legRegF xtmp, rRe
 %}
 
 // max = java.lang.Math.min(double a, double b)
-instruct minD_avx10_reg(regD dst, regD a, regD b) %{
+instruct minD_reg_avx10_2(regD dst, regD a, regD b) %{
   predicate(VM_Version::supports_avx10_2());
   match(Set dst (MinD a b));
   format %{ "minD $dst, $a, $b" %}
   ins_encode %{
-    __ eminmaxsd($dst$$XMMRegister, $a$$XMMRegister, $b$$XMMRegister, AVX10_MINMAX_MIN_COMPARE_SIGN);
+    __ eminmaxsd($dst$$XMMRegister, $a$$XMMRegister, $b$$XMMRegister, AVX10_2_MINMAX_MIN_COMPARE_SIGN);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -14587,7 +14587,7 @@ instruct convF2I_reg_reg(rRegI dst, regF src, rFlagsReg cr)
   ins_pipe(pipe_slow);
 %}
 
-instruct convF2I_reg_reg_avx10(rRegI dst, regF src)
+instruct convF2I_reg_reg_avx10_2(rRegI dst, regF src)
 %{
   predicate(VM_Version::supports_avx10_2());
   match(Set dst (ConvF2I src));
@@ -14598,7 +14598,7 @@ instruct convF2I_reg_reg_avx10(rRegI dst, regF src)
   ins_pipe(pipe_slow);
 %}
 
-instruct convF2I_reg_mem_avx10(rRegI dst, memory src)
+instruct convF2I_reg_mem_avx10_2(rRegI dst, memory src)
 %{
   predicate(VM_Version::supports_avx10_2());
   match(Set dst (ConvF2I (LoadF src)));
@@ -14621,7 +14621,7 @@ instruct convF2L_reg_reg(rRegL dst, regF src, rFlagsReg cr)
   ins_pipe(pipe_slow);
 %}
 
-instruct convF2L_reg_reg_avx10(rRegL dst, regF src)
+instruct convF2L_reg_reg_avx10_2(rRegL dst, regF src)
 %{
   predicate(VM_Version::supports_avx10_2());
   match(Set dst (ConvF2L src));
@@ -14632,7 +14632,7 @@ instruct convF2L_reg_reg_avx10(rRegL dst, regF src)
   ins_pipe(pipe_slow);
 %}
 
-instruct convF2L_reg_mem_avx10(rRegL dst, memory src)
+instruct convF2L_reg_mem_avx10_2(rRegL dst, memory src)
 %{
   predicate(VM_Version::supports_avx10_2());
   match(Set dst (ConvF2L (LoadF src)));
@@ -14655,7 +14655,7 @@ instruct convD2I_reg_reg(rRegI dst, regD src, rFlagsReg cr)
   ins_pipe(pipe_slow);
 %}
 
-instruct convD2I_reg_reg_avx10(rRegI dst, regD src)
+instruct convD2I_reg_reg_avx10_2(rRegI dst, regD src)
 %{
   predicate(VM_Version::supports_avx10_2());
   match(Set dst (ConvD2I src));
@@ -14666,7 +14666,7 @@ instruct convD2I_reg_reg_avx10(rRegI dst, regD src)
   ins_pipe(pipe_slow);
 %}
 
-instruct convD2I_reg_mem_avx10(rRegI dst, memory src)
+instruct convD2I_reg_mem_avx10_2(rRegI dst, memory src)
 %{
   predicate(VM_Version::supports_avx10_2());
   match(Set dst (ConvD2I (LoadD src)));
@@ -14689,7 +14689,7 @@ instruct convD2L_reg_reg(rRegL dst, regD src, rFlagsReg cr)
   ins_pipe(pipe_slow);
 %}
 
-instruct convD2L_reg_reg_avx10(rRegL dst, regD src)
+instruct convD2L_reg_reg_avx10_2(rRegL dst, regD src)
 %{
   predicate(VM_Version::supports_avx10_2());
   match(Set dst (ConvD2L src));
@@ -14700,7 +14700,7 @@ instruct convD2L_reg_reg_avx10(rRegL dst, regD src)
   ins_pipe(pipe_slow);
 %}
 
-instruct convD2L_reg_mem_avx10(rRegL dst, memory src)
+instruct convD2L_reg_mem_avx10_2(rRegL dst, memory src)
 %{
   predicate(VM_Version::supports_avx10_2());
   match(Set dst (ConvD2L (LoadD src)));
@@ -19661,7 +19661,7 @@ instruct minmax_reductionF_av(legRegF dst, legVec src, legVec tmp, legVec atmp, 
   ins_pipe( pipe_slow );
 %}
 
-instruct minmax_reduction2F_avx10(regF dst, immF src1, vec src2, vec xtmp1) %{
+instruct minmax_reduction2F_avx10_2(regF dst, immF src1, vec src2, vec xtmp1) %{
   predicate(VM_Version::supports_avx10_2() && Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT &&
             ((n->Opcode() == Op_MinReductionV && n->in(1)->bottom_type() == TypeF::POS_INF) ||
              (n->Opcode() == Op_MaxReductionV && n->in(1)->bottom_type() == TypeF::NEG_INF)) &&
@@ -19679,7 +19679,7 @@ instruct minmax_reduction2F_avx10(regF dst, immF src1, vec src2, vec xtmp1) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct minmax_reductionF_avx10(regF dst, immF src1, vec src2, vec xtmp1, vec xtmp2) %{
+instruct minmax_reductionF_avx10_2(regF dst, immF src1, vec src2, vec xtmp1, vec xtmp2) %{
   predicate(VM_Version::supports_avx10_2() && Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT &&
             ((n->Opcode() == Op_MinReductionV && n->in(1)->bottom_type() == TypeF::POS_INF) ||
              (n->Opcode() == Op_MaxReductionV && n->in(1)->bottom_type() == TypeF::NEG_INF)) &&
@@ -19697,7 +19697,7 @@ instruct minmax_reductionF_avx10(regF dst, immF src1, vec src2, vec xtmp1, vec x
   ins_pipe( pipe_slow );
 %}
 
-instruct minmax_reduction2F_avx10_av(regF dst, vec src, vec xtmp1) %{
+instruct minmax_reduction2F_av_avx10_2(regF dst, vec src, vec xtmp1) %{
   predicate(VM_Version::supports_avx10_2() && Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT &&
             Matcher::vector_length(n->in(2)) == 2);
   match(Set dst (MinReductionV dst src));
@@ -19713,7 +19713,7 @@ instruct minmax_reduction2F_avx10_av(regF dst, vec src, vec xtmp1) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct minmax_reductionF_avx10_av(regF dst, vec src, vec xtmp1, vec xtmp2) %{
+instruct minmax_reductionF_av_avx10_2(regF dst, vec src, vec xtmp1, vec xtmp2) %{
   predicate(VM_Version::supports_avx10_2() && Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT &&
             Matcher::vector_length(n->in(2)) >= 4);
   match(Set dst (MinReductionV dst src));
@@ -19811,7 +19811,7 @@ instruct minmax_reductionD_av(legRegD dst, legVec src, legVec tmp1, legVec tmp2,
   ins_pipe( pipe_slow );
 %}
 
-instruct minmax_reduction2D_avx10(regD dst, immD src1, vec src2, vec xtmp1) %{
+instruct minmax_reduction2D_avx10_2(regD dst, immD src1, vec src2, vec xtmp1) %{
   predicate(VM_Version::supports_avx10_2() && Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE &&
             ((n->Opcode() == Op_MinReductionV && n->in(1)->bottom_type() == TypeD::POS_INF) ||
              (n->Opcode() == Op_MaxReductionV && n->in(1)->bottom_type() == TypeD::NEG_INF)) &&
@@ -19829,7 +19829,7 @@ instruct minmax_reduction2D_avx10(regD dst, immD src1, vec src2, vec xtmp1) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct minmax_reductionD_avx10(regD dst, immD src1, vec src2, vec xtmp1, vec xtmp2) %{
+instruct minmax_reductionD_avx10_2(regD dst, immD src1, vec src2, vec xtmp1, vec xtmp2) %{
   predicate(VM_Version::supports_avx10_2() && Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE &&
             ((n->Opcode() == Op_MinReductionV && n->in(1)->bottom_type() == TypeD::POS_INF) ||
              (n->Opcode() == Op_MaxReductionV && n->in(1)->bottom_type() == TypeD::NEG_INF)) &&
@@ -19848,7 +19848,7 @@ instruct minmax_reductionD_avx10(regD dst, immD src1, vec src2, vec xtmp1, vec x
 %}
 
 
-instruct minmax_reduction2D_av_avx10(regD dst, vec src, vec xtmp1) %{
+instruct minmax_reduction2D_av_avx10_2(regD dst, vec src, vec xtmp1) %{
   predicate(VM_Version::supports_avx10_2() && Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE &&
             Matcher::vector_length(n->in(2)) == 2);
   match(Set dst (MinReductionV dst src));
@@ -19864,7 +19864,7 @@ instruct minmax_reduction2D_av_avx10(regD dst, vec src, vec xtmp1) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct minmax_reductionD_av_avx10(regD dst, vec src, vec xtmp1, vec xtmp2) %{
+instruct minmax_reductionD_av_avx10_2(regD dst, vec src, vec xtmp1, vec xtmp2) %{
   predicate(VM_Version::supports_avx10_2() && Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE &&
             Matcher::vector_length(n->in(2)) >= 4);
   match(Set dst (MinReductionV dst src));
@@ -20767,7 +20767,7 @@ instruct vminmaxL_reg_evex(vec dst, vec src1, vec src2) %{
 %}
 
 // Float/Double vector Min/Max
-instruct minmaxFP_avx10_reg(vec dst, vec a, vec b) %{
+instruct minmaxFP_reg_avx10_2(vec dst, vec a, vec b) %{
   predicate(VM_Version::supports_avx10_2() &&
             is_floating_point_type(Matcher::vector_element_basic_type(n))); // T_FLOAT, T_DOUBLE
   match(Set dst (MinV a b));
@@ -22114,29 +22114,29 @@ instruct castFtoX_reg_evex(vec dst, vec src, vec xtmp1, vec xtmp2, kReg ktmp1, k
   ins_pipe( pipe_slow );
 %}
 
-instruct castFtoX_reg_avx10(vec dst, vec src) %{
+instruct castFtoX_reg_avx10_2(vec dst, vec src) %{
   predicate(VM_Version::supports_avx10_2() &&
             is_integral_type(Matcher::vector_element_basic_type(n)));
   match(Set dst (VectorCastF2X src));
-  format %{ "vector_cast_f2x_avx10 $dst, $src\t!" %}
+  format %{ "vector_cast_f2x_avx10_2 $dst, $src\t!" %}
   ins_encode %{
     BasicType to_elem_bt = Matcher::vector_element_basic_type(this);
     int vlen_enc = (to_elem_bt == T_LONG) ? vector_length_encoding(this) : vector_length_encoding(this, $src);
-    __ vector_castF2X_avx10(to_elem_bt, $dst$$XMMRegister, $src$$XMMRegister, vlen_enc);
+    __ vector_castF2X_avx10_2(to_elem_bt, $dst$$XMMRegister, $src$$XMMRegister, vlen_enc);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct castFtoX_mem_avx10(vec dst, memory src) %{
+instruct castFtoX_mem_avx10_2(vec dst, memory src) %{
   predicate(VM_Version::supports_avx10_2() &&
             is_integral_type(Matcher::vector_element_basic_type(n)));
   match(Set dst (VectorCastF2X (LoadVector src)));
-  format %{ "vector_cast_f2x_avx10 $dst, $src\t!" %}
+  format %{ "vector_cast_f2x_avx10_2 $dst, $src\t!" %}
   ins_encode %{
     int vlen = Matcher::vector_length(this);
     BasicType to_elem_bt = Matcher::vector_element_basic_type(this);
     int vlen_enc = (to_elem_bt == T_LONG) ? vector_length_encoding(this) : vector_length_encoding(vlen * sizeof(jfloat));
-    __ vector_castF2X_avx10(to_elem_bt, $dst$$XMMRegister, $src$$Address, vlen_enc);
+    __ vector_castF2X_avx10_2(to_elem_bt, $dst$$XMMRegister, $src$$Address, vlen_enc);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -22188,29 +22188,29 @@ instruct castDtoX_reg_evex(vec dst, vec src, vec xtmp1, vec xtmp2, kReg ktmp1, k
   ins_pipe( pipe_slow );
 %}
 
-instruct castDtoX_reg_avx10(vec dst, vec src) %{
+instruct castDtoX_reg_avx10_2(vec dst, vec src) %{
   predicate(VM_Version::supports_avx10_2() &&
             is_integral_type(Matcher::vector_element_basic_type(n)));
   match(Set dst (VectorCastD2X src));
-  format %{ "vector_cast_d2x_avx10 $dst, $src\t!" %}
+  format %{ "vector_cast_d2x_avx10_2 $dst, $src\t!" %}
   ins_encode %{
     int vlen_enc = vector_length_encoding(this, $src);
     BasicType to_elem_bt = Matcher::vector_element_basic_type(this);
-    __ vector_castD2X_avx10(to_elem_bt, $dst$$XMMRegister, $src$$XMMRegister, vlen_enc);
+    __ vector_castD2X_avx10_2(to_elem_bt, $dst$$XMMRegister, $src$$XMMRegister, vlen_enc);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct castDtoX_mem_avx10(vec dst, memory src) %{
+instruct castDtoX_mem_avx10_2(vec dst, memory src) %{
   predicate(VM_Version::supports_avx10_2() &&
             is_integral_type(Matcher::vector_element_basic_type(n)));
   match(Set dst (VectorCastD2X (LoadVector src)));
-  format %{ "vector_cast_d2x_avx10 $dst, $src\t!" %}
+  format %{ "vector_cast_d2x_avx10_2 $dst, $src\t!" %}
   ins_encode %{
     int vlen = Matcher::vector_length(this);
     int vlen_enc = vector_length_encoding(vlen * sizeof(jdouble));
     BasicType to_elem_bt = Matcher::vector_element_basic_type(this);
-    __ vector_castD2X_avx10(to_elem_bt, $dst$$XMMRegister, $src$$Address, vlen_enc);
+    __ vector_castD2X_avx10_2(to_elem_bt, $dst$$XMMRegister, $src$$Address, vlen_enc);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -25182,14 +25182,14 @@ instruct scalar_binOps_HF_reg(regF dst, regF src1, regF src2)
   ins_pipe(pipe_slow);
 %}
 
-instruct scalar_minmax_HF_avx10_reg(regF dst, regF src1, regF src2)
+instruct scalar_minmax_HF_reg_avx10_2(regF dst, regF src1, regF src2)
 %{
   predicate(VM_Version::supports_avx10_2());
   match(Set dst (MaxHF src1 src2));
   match(Set dst (MinHF src1 src2));
   format %{ "scalar_min_max_fp16 $dst, $src1, $src2" %}
   ins_encode %{
-    int function = this->ideal_Opcode() == Op_MinHF ? AVX10_MINMAX_MIN_COMPARE_SIGN : AVX10_MINMAX_MAX_COMPARE_SIGN;
+    int function = this->ideal_Opcode() == Op_MinHF ? AVX10_2_MINMAX_MIN_COMPARE_SIGN : AVX10_2_MINMAX_MAX_COMPARE_SIGN;
     __ eminmaxsh($dst$$XMMRegister, $src1$$XMMRegister, $src2$$XMMRegister, function);
   %}
   ins_pipe( pipe_slow );
@@ -25297,7 +25297,7 @@ instruct vector_fma_HF_mem(vec dst, memory src1, vec src2)
   ins_pipe( pipe_slow );
 %}
 
-instruct vector_minmax_HF_avx10_mem(vec dst, vec src1, memory src2)
+instruct vector_minmax_HF_mem_avx10_2(vec dst, vec src1, memory src2)
 %{
   predicate(VM_Version::supports_avx10_2());
   match(Set dst (MinVHF src1 (VectorReinterpret (LoadVector src2))));
@@ -25305,13 +25305,13 @@ instruct vector_minmax_HF_avx10_mem(vec dst, vec src1, memory src2)
   format %{ "vector_min_max_fp16_mem $dst, $src1, $src2" %}
   ins_encode %{
     int vlen_enc = vector_length_encoding(this);
-    int function =  this->ideal_Opcode() == Op_MinVHF ? AVX10_MINMAX_MIN_COMPARE_SIGN : AVX10_MINMAX_MAX_COMPARE_SIGN;
+    int function =  this->ideal_Opcode() == Op_MinVHF ? AVX10_2_MINMAX_MIN_COMPARE_SIGN : AVX10_2_MINMAX_MAX_COMPARE_SIGN;
     __ evminmaxph($dst$$XMMRegister, k0, $src1$$XMMRegister, $src2$$Address, true, function, vlen_enc);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct vector_minmax_HF_avx10_reg(vec dst, vec src1, vec src2)
+instruct vector_minmax_HF_reg_avx10_2(vec dst, vec src1, vec src2)
 %{
   predicate(VM_Version::supports_avx10_2());
   match(Set dst (MinVHF src1 src2));
@@ -25319,7 +25319,7 @@ instruct vector_minmax_HF_avx10_reg(vec dst, vec src1, vec src2)
   format %{ "vector_min_max_fp16 $dst, $src1, $src2" %}
   ins_encode %{
     int vlen_enc = vector_length_encoding(this);
-    int function =  this->ideal_Opcode() == Op_MinVHF ? AVX10_MINMAX_MIN_COMPARE_SIGN : AVX10_MINMAX_MAX_COMPARE_SIGN;
+    int function =  this->ideal_Opcode() == Op_MinVHF ? AVX10_2_MINMAX_MIN_COMPARE_SIGN : AVX10_2_MINMAX_MAX_COMPARE_SIGN;
     __ evminmaxph($dst$$XMMRegister, k0, $src1$$XMMRegister, $src2$$XMMRegister, true, function, vlen_enc);
   %}
   ins_pipe( pipe_slow );

--- a/test/hotspot/jtreg/compiler/floatingpoint/ScalarFPtoIntCastTest.java
+++ b/test/hotspot/jtreg/compiler/floatingpoint/ScalarFPtoIntCastTest.java
@@ -90,7 +90,7 @@ public class ScalarFPtoIntCastTest {
     @IR(counts = {IRNode.X86_SCONV_F2I, "> 0"},
         applyIfPlatform = {"x64", "true"},
         applyIfCPUFeature = {"avx10_2", "false"})
-    @IR(counts = {IRNode.X86_SCONV_F2I_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_SCONV_F2I_AVX10_2, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void float2int() {
         for (int i = 0; i < COUNT; i++) {
@@ -106,7 +106,7 @@ public class ScalarFPtoIntCastTest {
     @IR(counts = {IRNode.X86_SCONV_F2L, "> 0"},
         applyIfPlatform = {"x64", "true"},
         applyIfCPUFeature = {"avx10_2", "false"})
-    @IR(counts = {IRNode.X86_SCONV_F2L_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_SCONV_F2L_AVX10_2, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void float2long() {
         for (int i = 0; i < COUNT; i++) {
@@ -122,7 +122,7 @@ public class ScalarFPtoIntCastTest {
     @IR(counts = {IRNode.X86_SCONV_F2I, "> 0"},
         applyIfPlatform = {"x64", "true"},
         applyIfCPUFeature = {"avx10_2", "false"})
-    @IR(counts = {IRNode.X86_SCONV_F2I_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_SCONV_F2I_AVX10_2, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void float2short() {
         for (int i = 0; i < COUNT; i++) {
@@ -138,7 +138,7 @@ public class ScalarFPtoIntCastTest {
     @IR(counts = {IRNode.X86_SCONV_F2I, "> 0"},
         applyIfPlatform = {"x64", "true"},
         applyIfCPUFeature = {"avx10_2", "false"})
-    @IR(counts = {IRNode.X86_SCONV_F2I_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_SCONV_F2I_AVX10_2, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void float2byte() {
         for (int i = 0; i < COUNT; i++) {
@@ -154,7 +154,7 @@ public class ScalarFPtoIntCastTest {
     @IR(counts = {IRNode.X86_SCONV_D2I, "> 0"},
         applyIfPlatform = {"x64", "true"},
         applyIfCPUFeature = {"avx10_2", "false"})
-    @IR(counts = {IRNode.X86_SCONV_D2I_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_SCONV_D2I_AVX10_2, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void double2int() {
         for (int i = 0; i < COUNT; i++) {
@@ -170,7 +170,7 @@ public class ScalarFPtoIntCastTest {
     @IR(counts = {IRNode.X86_SCONV_D2L, "> 0"},
         applyIfPlatform = {"x64", "true"},
         applyIfCPUFeature = {"avx10_2", "false"})
-    @IR(counts = {IRNode.X86_SCONV_D2L_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_SCONV_D2L_AVX10_2, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void double2long() {
         for (int i = 0; i < COUNT; i++) {
@@ -186,7 +186,7 @@ public class ScalarFPtoIntCastTest {
     @IR(counts = {IRNode.X86_SCONV_D2I, "> 0"},
         applyIfPlatform = {"x64", "true"},
         applyIfCPUFeature = {"avx10_2", "false"})
-    @IR(counts = {IRNode.X86_SCONV_D2I_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_SCONV_D2I_AVX10_2, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void double2short() {
         for (int i = 0; i < COUNT; i++) {
@@ -202,7 +202,7 @@ public class ScalarFPtoIntCastTest {
     @IR(counts = {IRNode.X86_SCONV_D2I, "> 0"},
         applyIfPlatform = {"x64", "true"},
         applyIfCPUFeature = {"avx10_2", "false"})
-    @IR(counts = {IRNode.X86_SCONV_D2I_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_SCONV_D2I_AVX10_2, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void double2byte() {
         for (int i = 0; i < COUNT; i++) {

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -2756,24 +2756,24 @@ public class IRNode {
         machOnlyNameRegex(X86_SCONV_F2L, "convF2L_reg_reg");
     }
 
-    public static final String X86_SCONV_D2I_AVX10 = PREFIX + "X86_SCONV2_D2I_AVX10" + POSTFIX;
+    public static final String X86_SCONV_D2I_AVX10_2 = PREFIX + "X86_SCONV_D2I_AVX10_2" + POSTFIX;
     static {
-        machOnlyNameRegex(X86_SCONV_D2I_AVX10, "convD2I_(reg_reg|reg_mem)_avx10");
+        machOnlyNameRegex(X86_SCONV_D2I_AVX10_2, "convD2I_(reg_reg|reg_mem)_avx10_2");
     }
 
-    public static final String X86_SCONV_D2L_AVX10 = PREFIX + "X86_SCONV_D2L_AVX10" + POSTFIX;
+    public static final String X86_SCONV_D2L_AVX10_2 = PREFIX + "X86_SCONV_D2L_AVX10_2" + POSTFIX;
     static {
-        machOnlyNameRegex(X86_SCONV_D2L_AVX10, "convD2L_(reg_reg|reg_mem)_avx10");
+        machOnlyNameRegex(X86_SCONV_D2L_AVX10_2, "convD2L_(reg_reg|reg_mem)_avx10_2");
     }
 
-    public static final String X86_SCONV_F2I_AVX10 = PREFIX + "X86_SCONV_F2I_AVX10" + POSTFIX;
+    public static final String X86_SCONV_F2I_AVX10_2 = PREFIX + "X86_SCONV_F2I_AVX10_2" + POSTFIX;
     static {
-        machOnlyNameRegex(X86_SCONV_F2I_AVX10, "convF2I_(reg_reg|reg_mem)_avx10");
+        machOnlyNameRegex(X86_SCONV_F2I_AVX10_2, "convF2I_(reg_reg|reg_mem)_avx10_2");
     }
 
-    public static final String X86_SCONV_F2L_AVX10 = PREFIX + "X86_SCONV_F2L_AVX10" + POSTFIX;
+    public static final String X86_SCONV_F2L_AVX10_2 = PREFIX + "X86_SCONV_F2L_AVX10_2" + POSTFIX;
     static {
-        machOnlyNameRegex(X86_SCONV_F2L_AVX10, "convF2L_(reg_reg|reg_mem)_avx10");
+        machOnlyNameRegex(X86_SCONV_F2L_AVX10_2, "convF2L_(reg_reg|reg_mem)_avx10_2");
     }
 
     public static final String X86_VCAST_F2X = PREFIX + "X86_VCAST_F2X" + POSTFIX;
@@ -2786,14 +2786,14 @@ public class IRNode {
         machOnlyNameRegex(X86_VCAST_D2X, "castDtoX_reg_(av|eve)x");
     }
 
-    public static final String X86_VCAST_F2X_AVX10 = PREFIX + "X86_VCAST_F2X_AVX10" + POSTFIX;
+    public static final String X86_VCAST_F2X_AVX10_2 = PREFIX + "X86_VCAST_F2X_AVX10_2" + POSTFIX;
     static {
-        machOnlyNameRegex(X86_VCAST_F2X_AVX10, "castFtoX_(reg|mem)_avx10");
+        machOnlyNameRegex(X86_VCAST_F2X_AVX10_2, "castFtoX_(reg|mem)_avx10_2");
     }
 
-    public static final String X86_VCAST_D2X_AVX10 = PREFIX + "X86_VCAST_D2X_AVX10" + POSTFIX;
+    public static final String X86_VCAST_D2X_AVX10_2 = PREFIX + "X86_VCAST_D2X_AVX10_2" + POSTFIX;
     static {
-        machOnlyNameRegex(X86_VCAST_D2X_AVX10, "castDtoX_(reg|mem)_avx10");
+        machOnlyNameRegex(X86_VCAST_D2X_AVX10_2, "castDtoX_(reg|mem)_avx10_2");
     }
 
     public static final String XOR = PREFIX + "XOR" + POSTFIX;

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorFPtoIntCastTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorFPtoIntCastTest.java
@@ -90,7 +90,7 @@ public class VectorFPtoIntCastTest {
         applyIfCPUFeatureOr = {"avx512f", "true", "avx10_2", "true"})
     @IR(counts = {IRNode.X86_VCAST_F2X, "> 0"},
         applyIfCPUFeatureAnd = {"avx512f", "true", "avx10_2", "false"})
-    @IR(counts = {IRNode.X86_VCAST_F2X_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_VCAST_F2X_AVX10_2, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void float2int() {
         var cvec = (IntVector)fvec512.convertShape(VectorOperators.F2I, ispec512, 0);
@@ -112,7 +112,7 @@ public class VectorFPtoIntCastTest {
         applyIfCPUFeatureOr = {"avx512dq", "true", "avx10_2", "true"})
     @IR(counts = {IRNode.X86_VCAST_F2X, "> 0"},
         applyIfCPUFeatureAnd = {"avx512dq", "true", "avx10_2", "false"})
-    @IR(counts = {IRNode.X86_VCAST_F2X_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_VCAST_F2X_AVX10_2, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void float2long() {
         var cvec = (LongVector)fvec512.convertShape(VectorOperators.F2L, lspec512, 0);
@@ -134,7 +134,7 @@ public class VectorFPtoIntCastTest {
         applyIfCPUFeatureOr = {"avx512f", "true", "avx10_2", "true"})
     @IR(counts = {IRNode.X86_VCAST_F2X, "> 0"},
         applyIfCPUFeatureAnd = {"avx512f", "true", "avx10_2", "false"})
-    @IR(counts = {IRNode.X86_VCAST_F2X_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_VCAST_F2X_AVX10_2, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void float2short() {
         var cvec = (ShortVector)fvec512.convertShape(VectorOperators.F2S, sspec256, 0);
@@ -156,7 +156,7 @@ public class VectorFPtoIntCastTest {
         applyIfCPUFeatureOr = {"avx512f", "true", "avx10_2", "true"})
     @IR(counts = {IRNode.X86_VCAST_F2X, "> 0"},
         applyIfCPUFeatureAnd = {"avx512f", "true", "avx10_2", "false"})
-    @IR(counts = {IRNode.X86_VCAST_F2X_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_VCAST_F2X_AVX10_2, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void float2byte() {
         var cvec = (ByteVector)fvec512.convertShape(VectorOperators.F2B, bspec128, 0);
@@ -178,7 +178,7 @@ public class VectorFPtoIntCastTest {
         applyIfCPUFeatureOr = {"avx512f", "true", "avx10_2", "true"})
     @IR(counts = {IRNode.X86_VCAST_D2X, "> 0"},
         applyIfCPUFeatureAnd = {"avx512f", "true", "avx10_2", "false"})
-    @IR(counts = {IRNode.X86_VCAST_D2X_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_VCAST_D2X_AVX10_2, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void double2int() {
         var cvec = (IntVector)dvec512.convertShape(VectorOperators.D2I, ispec256, 0);
@@ -200,7 +200,7 @@ public class VectorFPtoIntCastTest {
         applyIfCPUFeatureOr = {"avx512dq", "true", "avx10_2", "true"})
     @IR(counts = {IRNode.X86_VCAST_D2X, "> 0"},
         applyIfCPUFeatureAnd = {"avx512dq", "true", "avx10_2", "false"})
-    @IR(counts = {IRNode.X86_VCAST_D2X_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_VCAST_D2X_AVX10_2, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void double2long() {
         var cvec = (LongVector)dvec512.convertShape(VectorOperators.D2L, lspec512, 0);
@@ -222,7 +222,7 @@ public class VectorFPtoIntCastTest {
         applyIfCPUFeatureOr = {"avx512f", "true", "avx10_2", "true"})
     @IR(counts = {IRNode.X86_VCAST_D2X, "> 0"},
         applyIfCPUFeatureAnd = {"avx512f", "true", "avx10_2", "false"})
-    @IR(counts = {IRNode.X86_VCAST_D2X_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_VCAST_D2X_AVX10_2, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void double2short() {
         var cvec = (ShortVector)dvec512.convertShape(VectorOperators.D2S, sspec128, 0);
@@ -244,7 +244,7 @@ public class VectorFPtoIntCastTest {
         applyIfCPUFeatureOr = {"avx512f", "true", "avx10_2", "true"})
     @IR(counts = {IRNode.X86_VCAST_D2X, "> 0"},
         applyIfCPUFeatureAnd = {"avx512f", "true", "avx10_2", "false"})
-    @IR(counts = {IRNode.X86_VCAST_D2X_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_VCAST_D2X_AVX10_2, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void double2byte() {
         var cvec = (ByteVector)dvec512.convertShape(VectorOperators.D2B, bspec64, 0);

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayTypeConvertTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayTypeConvertTest.java
@@ -298,7 +298,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
         counts = {IRNode.VECTOR_CAST_F2I, IRNode.VECTOR_SIZE + "min(max_float, max_int)", "> 0"})
     @IR(counts = {IRNode.X86_VCAST_F2X, "> 0"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx10_2", "false"})
-    @IR(counts = {IRNode.X86_VCAST_F2X_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_VCAST_F2X_AVX10_2, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public int[] convertFloatToInt() {
         int[] res = new int[SIZE];
@@ -313,7 +313,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
         counts = {IRNode.VECTOR_CAST_F2L, IRNode.VECTOR_SIZE + "min(max_float, max_long)", "> 0"})
     @IR(counts = {IRNode.X86_VCAST_F2X, "> 0"},
         applyIfCPUFeatureAnd = {"avx512dq", "true", "avx10_2", "false"})
-    @IR(counts = {IRNode.X86_VCAST_F2X_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_VCAST_F2X_AVX10_2, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public long[] convertFloatToLong() {
         long[] res = new long[SIZE];
@@ -328,7 +328,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
         counts = {IRNode.VECTOR_CAST_D2I, IRNode.VECTOR_SIZE + "min(max_double, max_int)", "> 0"})
     @IR(counts = {IRNode.X86_VCAST_D2X, "> 0"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx10_2", "false"})
-    @IR(counts = {IRNode.X86_VCAST_D2X_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_VCAST_D2X_AVX10_2, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public int[] convertDoubleToInt() {
         int[] res = new int[SIZE];
@@ -343,7 +343,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
         counts = {IRNode.VECTOR_CAST_D2L, IRNode.VECTOR_SIZE + "min(max_double, max_long)", "> 0"})
     @IR(counts = {IRNode.X86_VCAST_D2X, "> 0"},
         applyIfCPUFeatureAnd = {"avx512dq", "true", "avx10_2", "false"})
-    @IR(counts = {IRNode.X86_VCAST_D2X_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_VCAST_D2X_AVX10_2, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public long[] convertDoubleToLong() {
         long[] res = new long[SIZE];
@@ -361,7 +361,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     @IR(counts = {IRNode.X86_VCAST_F2X, "> 0"},
         applyIfOr = {"AlignVector", "false", "UseCompactObjectHeaders", "false"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx10_2", "false"})
-    @IR(counts = {IRNode.X86_VCAST_F2X_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_VCAST_F2X_AVX10_2, "> 0"},
         applyIfOr = {"AlignVector", "false", "UseCompactObjectHeaders", "false"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public short[] convertFloatToShort() {
@@ -386,7 +386,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     @IR(counts = {IRNode.X86_VCAST_F2X, "> 0"},
         applyIfOr = {"AlignVector", "false", "UseCompactObjectHeaders", "false"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx10_2", "false"})
-    @IR(counts = {IRNode.X86_VCAST_F2X_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_VCAST_F2X_AVX10_2, "> 0"},
         applyIfOr = {"AlignVector", "false", "UseCompactObjectHeaders", "false"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public char[] convertFloatToChar() {
@@ -414,7 +414,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     @IR(counts = {IRNode.X86_VCAST_D2X, "> 0"},
         applyIf = {"MaxVectorSize", ">=16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx10_2", "false"})
-    @IR(counts = {IRNode.X86_VCAST_D2X_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_VCAST_D2X_AVX10_2, "> 0"},
         applyIf = {"MaxVectorSize", ">=16"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public short[] convertDoubleToShort() {
@@ -435,7 +435,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     @IR(counts = {IRNode.X86_VCAST_D2X, "> 0"},
         applyIf = {"MaxVectorSize", ">=16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx10_2", "false"})
-    @IR(counts = {IRNode.X86_VCAST_D2X_AVX10, "> 0"},
+    @IR(counts = {IRNode.X86_VCAST_D2X_AVX10_2, "> 0"},
         applyIf = {"MaxVectorSize", ">=16"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public char[] convertDoubleToChar() {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [4f1dcf89](https://github.com/openjdk/jdk/commit/4f1dcf89b841e9a37d342bdf8c66bbbab9edb0d4) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Mohamed Issa on 13 Dec 2025 and was reviewed by Jatin Bhateja, Manuel Hässig and Vladimir Ivanov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8368977](https://bugs.openjdk.org/browse/JDK-8368977) needs maintainer approval

### Issue
 * [JDK-8368977](https://bugs.openjdk.org/browse/JDK-8368977): Provide clear naming for AVX10 identifiers (**Enhancement** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/150/head:pull/150` \
`$ git checkout pull/150`

Update a local copy of the PR: \
`$ git checkout pull/150` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 150`

View PR using the GUI difftool: \
`$ git pr show -t 150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/150.diff">https://git.openjdk.org/jdk26u/pull/150.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/150#issuecomment-4202857753)
</details>
