### PR TITLE
8381222: Running a custom runtime image with AOTCache fails with "Unexpected exception" [jdk26]

### DIFF
--- a/src/hotspot/share/cds/aotArtifactFinder.cpp
+++ b/src/hotspot/share/cds/aotArtifactFinder.cpp
@@ -146,6 +146,12 @@ void AOTArtifactFinder::find_artifacts() {
 #if INCLUDE_CDS_JAVA_HEAP
   // Keep scanning until we discover no more class that need to be AOT-initialized.
   if (CDSConfig::is_initing_classes_at_dump_time()) {
+ // Fix JDK-8381222 (JDK 26 only)
+ // Ensure that jdk.internal.loader.ClassLoaders${Platform,App}ClassLoader are
+ // AOT-initialized even if one or both of these loaders have no modules in the archived FMG.
+ add_aot_inited_class(InstanceKlass::cast(SystemDictionary::java_platform_loader()->klass()));
+ add_aot_inited_class(InstanceKlass::cast(SystemDictionary::java_system_loader()->klass()));
+
     while (_pending_aot_inited_classes->length() > 0) {
       InstanceKlass* ik = _pending_aot_inited_classes->pop();
       HeapShared::copy_and_rescan_aot_inited_mirror(ik);


### PR DESCRIPTION
This PR allows applications to start with both a custom image and an AOT cache file.

Testing:
1. Reproducer
The application started successfully with the JDK including this fix.
2. Tier1–5
No regressions were observed. Some tests failed, but they are not related to this fix.
3. jtreg tests (`test/hotspot/jtreg/runtime/cds/appcds/aotCache/`)
All tests passed on all platforms.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8381222](https://bugs.openjdk.org/browse/JDK-8381222) needs maintainer approval

### Issue
 * [JDK-8381222](https://bugs.openjdk.org/browse/JDK-8381222): Running a custom runtime image with AOTCache fails with "Unexpected exception" [jdk26] (**Bug** - P3 - Requested) ⚠️ Issue is not open.


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/154/head:pull/154` \
`$ git checkout pull/154`

Update a local copy of the PR: \
`$ git checkout pull/154` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/154/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 154`

View PR using the GUI difftool: \
`$ git pr show -t 154`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/154.diff">https://git.openjdk.org/jdk26u/pull/154.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/154#issuecomment-4211567268)
</details>
