### PR TITLE
8381745: Ensure Modal/FileDialog tests explicitly reference Asserts class

### DIFF
--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogAppModal1Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogAppModal1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogAppModal2Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogAppModal2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogAppModal3Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogAppModal3Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogAppModal4Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogAppModal4Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogAppModal5Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogAppModal5Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogAppModal6Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogAppModal6Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogDWDTest.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogDWDTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,11 @@
  */
 
 
-import java.awt.*;
+import java.awt.Dialog;
+import java.awt.EventQueue;
+import java.awt.FileDialog;
+import java.awt.Frame;
+import java.awt.Toolkit;
 
 
 // DWD: Dialog, Window, Dialog

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogDocModal1Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogDocModal1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogDocModal2Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogDocModal2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogDocModal3Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogDocModal3Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogDocModal4Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogDocModal4Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogDocModal5Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogDocModal5Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogDocModal6Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogDocModal6Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogDocModal7Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogDocModal7Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogFWDTest.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogFWDTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,8 +21,11 @@
  * questions.
  */
 
-import java.awt.*;
-
+import java.awt.Dialog;
+import java.awt.EventQueue;
+import java.awt.FileDialog;
+import java.awt.Frame;
+import java.awt.Toolkit;
 
 
 // FWD: Frame, Window, Dialog

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogModal1Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogModal1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogModal2Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogModal2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogModal3Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogModal3Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogModal4Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogModal4Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogModal5Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogModal5Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogModal6Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogModal6Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogModalityTest.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogModalityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,11 @@
  * questions.
  */
 
-import java.awt.*;
+import java.awt.Dialog;
+import java.awt.EventQueue;
+import java.awt.FileDialog;
+import java.awt.Frame;
+import java.awt.Toolkit;
 
 public class FileDialogModalityTest {
 

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogNonModal1Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogNonModal1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogNonModal2Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogNonModal2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogNonModal3Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogNonModal3Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogNonModal4Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogNonModal4Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogNonModal5Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogNonModal5Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogNonModal6Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogNonModal6Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogNonModal7Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogNonModal7Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogTKModal1Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogTKModal1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogTKModal2Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogTKModal2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogTKModal3Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogTKModal3Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogTKModal4Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogTKModal4Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogTKModal5Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogTKModal5Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogTKModal6Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogTKModal6Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/FileDialog/FileDialogTKModal7Test.java
+++ b/test/jdk/java/awt/Modal/FileDialog/FileDialogTKModal7Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.awt.Dialog;
  * @library ../helpers /lib/client/
  * @library /test/lib
  * @build ExtendedRobot
+ * @build jdk.test.lib.Asserts
  * @build Flag
  * @build TestDialog
  * @build TestFrame

--- a/test/jdk/java/awt/Modal/helpers/TestDialog.java
+++ b/test/jdk/java/awt/Modal/helpers/TestDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,11 +22,23 @@
  */
 
 
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.Button;
+import java.awt.Dialog;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowFocusListener;
+import java.awt.event.WindowListener;
 
-import static jdk.test.lib.Asserts.*;
-
+import static jdk.test.lib.Asserts.assertEQ;
+import static jdk.test.lib.Asserts.assertFalse;
+import static jdk.test.lib.Asserts.assertTrue;
 
 
 public class TestDialog extends Dialog implements ActionListener,

--- a/test/jdk/java/awt/Modal/helpers/TestFrame.java
+++ b/test/jdk/java/awt/Modal/helpers/TestFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,22 @@
  * questions.
  */
 
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowFocusListener;
+import java.awt.event.WindowListener;
 
-import static jdk.test.lib.Asserts.*;
-
+import static jdk.test.lib.Asserts.assertEQ;
+import static jdk.test.lib.Asserts.assertFalse;
+import static jdk.test.lib.Asserts.assertTrue;
 
 
 public class TestFrame extends Frame implements ActionListener,

--- a/test/jdk/java/awt/Modal/helpers/TestWindow.java
+++ b/test/jdk/java/awt/Modal/helpers/TestWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,23 @@
  * questions.
  */
 
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.Window;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowFocusListener;
+import java.awt.event.WindowListener;
 
-import static jdk.test.lib.Asserts.*;
-
+import static jdk.test.lib.Asserts.assertEQ;
+import static jdk.test.lib.Asserts.assertFalse;
+import static jdk.test.lib.Asserts.assertTrue;
 
 
 public class TestWindow extends Window implements ActionListener,


### PR DESCRIPTION
This pull request contains a backport of commit [cfae18fa](https://github.com/openjdk/jdk/commit/cfae18fa606d8924f1f020b0f2de8617dd648bb2) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Alexey Ivanov on 8 Apr 2026 and was reviewed by Sergey Bylokhov and Dmitry Markov.

The backport is *clean*.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8381745](https://bugs.openjdk.org/browse/JDK-8381745) needs maintainer approval

### Issue
 * [JDK-8381745](https://bugs.openjdk.org/browse/JDK-8381745): Ensure Modal/FileDialog tests explicitly reference Asserts class (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/155/head:pull/155` \
`$ git checkout pull/155`

Update a local copy of the PR: \
`$ git checkout pull/155` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 155`

View PR using the GUI difftool: \
`$ git pr show -t 155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/155.diff">https://git.openjdk.org/jdk26u/pull/155.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/155#issuecomment-4216145594)
</details>
