### PR TITLE
8376152: Test javax/sound/sampled/Clip/bug5070081.java timed out then completed

### DIFF
--- a/test/jdk/javax/sound/sampled/Clip/bug5070081.java
+++ b/test/jdk/javax/sound/sampled/Clip/bug5070081.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,8 @@ import javax.sound.sampled.LineUnavailableException;
 
 /*
  * @test
- * @bug 5070081
+ * @key sound
+ * @bug 5070081 8376152
  * @summary Tests that javax.sound.sampled.Clip does not loses position through
  *          stop/start
  */


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [0ab8a85e](https://github.com/openjdk/jdk/commit/0ab8a85e87cb607c48a45900550998f0d36cf761) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Phil Race on 25 Feb 2026 and was reviewed by SendaoYan, Alexey Ivanov and Alexander Zvegintsev.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8376152](https://bugs.openjdk.org/browse/JDK-8376152) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8376152](https://bugs.openjdk.org/browse/JDK-8376152): Test javax/sound/sampled/Clip/bug5070081.java timed out then completed (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/164/head:pull/164` \
`$ git checkout pull/164`

Update a local copy of the PR: \
`$ git checkout pull/164` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 164`

View PR using the GUI difftool: \
`$ git pr show -t 164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/164.diff">https://git.openjdk.org/jdk26u/pull/164.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/164#issuecomment-4249782957)
</details>
