### PR TITLE
8379425: Windows and macOS should not allow unsupported headless-only build

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -102,6 +102,13 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_JDK_OPTIONS],
       CHECKING_MSG: [if we should build headless-only (no GUI)])
   AC_SUBST(ENABLE_HEADLESS_ONLY)
 
+  # Avoid headless-only on macOS and Windows, it is not supported there
+  if test "x$ENABLE_HEADLESS_ONLY" = xtrue; then
+    if test "x$OPENJDK_TARGET_OS" = xwindows || test "x$OPENJDK_TARGET_OS" = xmacosx; then
+      AC_MSG_ERROR([headless-only is not supported on macOS and Windows])
+    fi
+  fi
+
   # should we linktime gc unused code sections in the JDK build ?
   if test "x$OPENJDK_TARGET_OS" = "xlinux"; then
     if test "x$OPENJDK_TARGET_CPU" = "xs390x" || test "x$OPENJDK_TARGET_CPU" = "xppc64le"; then


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8379425](https://bugs.openjdk.org/browse/JDK-8379425) needs maintainer approval

### Issue
 * [JDK-8379425](https://bugs.openjdk.org/browse/JDK-8379425): Windows and macOS should not allow unsupported headless-only build (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/168/head:pull/168` \
`$ git checkout pull/168`

Update a local copy of the PR: \
`$ git checkout pull/168` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 168`

View PR using the GUI difftool: \
`$ git pr show -t 168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/168.diff">https://git.openjdk.org/jdk26u/pull/168.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/168#issuecomment-4260381299)
</details>
