### PR TITLE
8376479: Http3 test server thread deadlock in ThrowingPublishersInRequest

### DIFF
--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http3/Http3ServerExchange.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http3/Http3ServerExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -175,7 +175,7 @@ public final class Http3ServerExchange implements Http2TestExchange {
             }
             serverStream.writer.reset(Http3Error.H3_INTERNAL_ERROR.code());
         }
-        is.close(io);
+        is.resetStream(io);
         os.closeInternal();
         close();
     }


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8376479](https://bugs.openjdk.org/browse/JDK-8376479) needs maintainer approval

### Issue
 * [JDK-8376479](https://bugs.openjdk.org/browse/JDK-8376479): Http3 test server thread deadlock in ThrowingPublishersInRequest (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/169/head:pull/169` \
`$ git checkout pull/169`

Update a local copy of the PR: \
`$ git checkout pull/169` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 169`

View PR using the GUI difftool: \
`$ git pr show -t 169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/169.diff">https://git.openjdk.org/jdk26u/pull/169.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/169#issuecomment-4265928245)
</details>
