### PR TITLE
8382090: Remove .rej and .orig from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,6 @@ NashornProfile.txt
 /.gdbinit
 /.lldbinit
 **/core.[0-9]*
-*.rej
-*.orig
 test/benchmarks/**/target
 /src/hotspot/CMakeLists.txt
 /src/hotspot/compile_commands.json


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [35f623b6](https://github.com/openjdk/jdk/commit/35f623b61279a448e2ddcbb6e1ba9eebe4dee8e2) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Ivan Bereziuk on 20 Apr 2026 and was reviewed by Alexey Ivanov, Erik Joelsson, SendaoYan and Chen Liang.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Issue
 * [JDK-8382090](https://bugs.openjdk.org/browse/JDK-8382090): Remove .rej and .orig from .gitignore (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/170/head:pull/170` \
`$ git checkout pull/170`

Update a local copy of the PR: \
`$ git checkout pull/170` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 170`

View PR using the GUI difftool: \
`$ git pr show -t 170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/170.diff">https://git.openjdk.org/jdk26u/pull/170.diff</a>

</details>
