### PR TITLE
8377534: Test java/awt/print/PrinterJob/PrintNullString.java fails with FAILURE: No IAE for empty iterator, int

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/PrintNullString.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintNullString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javax.print.attribute.standard.Destination;
 
 /*
  * @test
- * @bug 4223328
+ * @bug 4223328 4138921
  * @summary Printer graphics must throw expected exceptions
  * @key printer
  * @run main PrintNullString
@@ -106,12 +106,8 @@ public class PrintNullString implements Printable {
             g2d.drawString("caught expected NPE for null iterator, int", 20, 120);
         }
 
-        try {
-            g2d.drawString(emptyIterator, 20, 140);
-            throw new RuntimeException("FAILURE: No IAE for empty iterator, int");
-        } catch (IllegalArgumentException e) {
-            g2d.drawString("caught expected IAE for empty iterator, int", 20, 140);
-        }
+        g2d.drawString(emptyIterator, 20, 140);
+        g2d.drawString("OK for empty iterator, int", 20, 140);
 
         // API 4: null & empty drawString(Iterator, float, int);
         try {
@@ -121,12 +117,8 @@ public class PrintNullString implements Printable {
             g2d.drawString("caught expected NPE for null iterator, float", 20, 160);
         }
 
-        try {
-            g2d.drawString(emptyIterator, 20.0f, 180.0f);
-            throw new RuntimeException("FAILURE: No IAE for empty iterator, float");
-        } catch (IllegalArgumentException e) {
-            g2d.drawString("caught expected IAE for empty iterator, float", 20, 180);
-        }
+        g2d.drawString(emptyIterator, 20.0f, 180.0f);
+        g2d.drawString("OK for empty iterator, float", 20.0f, 100.f);
 
         return PAGE_EXISTS;
     }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [7527da08](https://github.com/openjdk/jdk/commit/7527da081b777f280144af5841874729a671e9c5) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Trupti Patil on 30 Mar 2026 and was reviewed by Alexey Ivanov and Phil Race.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8377534](https://bugs.openjdk.org/browse/JDK-8377534) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8377534](https://bugs.openjdk.org/browse/JDK-8377534): Test java/awt/print/PrinterJob/PrintNullString.java fails with FAILURE: No IAE for empty iterator, int (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/171/head:pull/171` \
`$ git checkout pull/171`

Update a local copy of the PR: \
`$ git checkout pull/171` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 171`

View PR using the GUI difftool: \
`$ git pr show -t 171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/171.diff">https://git.openjdk.org/jdk26u/pull/171.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/171#issuecomment-4278491849)
</details>
