### PR TITLE
8380824: java/net/DatagramSocket/SendReceiveMaxSize.java could also test the loopback interface

### DIFF
--- a/test/jdk/java/net/DatagramSocket/SendReceiveMaxSize.java
+++ b/test/jdk/java/net/DatagramSocket/SendReceiveMaxSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,6 +55,8 @@ import java.net.MulticastSocket;
 import java.nio.channels.DatagramChannel;
 import java.util.Random;
 
+import static java.net.StandardSocketOptions.SO_RCVBUF;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.expectThrows;
 
@@ -102,6 +104,10 @@ public class SendReceiveMaxSize {
                                        DatagramSocketSupplier supplier,
                                        Class<? extends Exception> exception) throws IOException {
         try (var receiver = new DatagramSocket(new InetSocketAddress(HOST_ADDR, 0))) {
+            assertTrue(receiver.getOption(SO_RCVBUF) >= capacity,
+                       receiver.getOption(SO_RCVBUF) +
+                       " for UDP receive buffer too small to hold capacity " +
+                       capacity);
             var port = receiver.getLocalPort();
             var addr = new InetSocketAddress(HOST_ADDR, port);
             try (var sender = supplier.open()) {


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8380824](https://bugs.openjdk.org/browse/JDK-8380824) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8380824](https://bugs.openjdk.org/browse/JDK-8380824): java/net/DatagramSocket/SendReceiveMaxSize.java could also test the loopback interface (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/175/head:pull/175` \
`$ git checkout pull/175`

Update a local copy of the PR: \
`$ git checkout pull/175` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 175`

View PR using the GUI difftool: \
`$ git pr show -t 175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/175.diff">https://git.openjdk.org/jdk26u/pull/175.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/175#issuecomment-4292725308)
</details>
