### PR TITLE
8379457: Test EATests.java#id0 ERROR: monitor list errors: error_cnt=1

### DIFF
--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1415,7 +1415,11 @@ void ObjectSynchronizer::chk_in_use_entry(ObjectMonitor* n, outputStream* out,
   }
 
   const markWord mark = obj->mark();
-  if (!mark.has_monitor()) {
+  // Note: When using ObjectMonitorTable we may observe an intermediate state,
+  // where the monitor is globally visible, but no thread has yet transitioned
+  // the markWord. To avoid reporting a false positive during this transition, we
+  // skip the `!mark.has_monitor()` test if we are using the ObjectMonitorTable.
+  if (!UseObjectMonitorTable && !mark.has_monitor()) {
     out->print_cr("ERROR: monitor=" INTPTR_FORMAT ": in-use monitor's "
                   "object does not think it has a monitor: obj="
                   INTPTR_FORMAT ", mark=" INTPTR_FORMAT, p2i(n),


### PR DESCRIPTION
This pull request contains a backport of commit [d3be157f](https://github.com/openjdk/jdk/commit/d3be157fd5f94502e73dd2bda35653a4ea95248d) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Fredrik Bredberg on 16 Mar 2026 and was reviewed by Anton Artemov, Axel Boldt-Christmas and David Holmes.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8379457](https://bugs.openjdk.org/browse/JDK-8379457) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8379457](https://bugs.openjdk.org/browse/JDK-8379457): Test EATests.java#id0 ERROR: monitor list errors: error_cnt=1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/176/head:pull/176` \
`$ git checkout pull/176`

Update a local copy of the PR: \
`$ git checkout pull/176` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 176`

View PR using the GUI difftool: \
`$ git pr show -t 176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/176.diff">https://git.openjdk.org/jdk26u/pull/176.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/176#issuecomment-4295281692)
</details>
