### PR TITLE
8374051: Incorrect parameterized testing of exceptions in AbstractDateTimeTest.java

### DIFF
--- a/test/jdk/java/time/tck/java/time/AbstractDateTimeTest.java
+++ b/test/jdk/java/time/tck/java/time/AbstractDateTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,8 +59,11 @@
  */
 package tck.java.time;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.temporal.TemporalAccessor;
@@ -68,8 +71,8 @@ import java.time.temporal.TemporalField;
 import java.time.temporal.TemporalQuery;
 import java.util.List;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import test.java.time.temporal.MockFieldNoValue;
 
@@ -99,183 +102,137 @@ public abstract class AbstractDateTimeTest extends AbstractTCKTest {
     //-----------------------------------------------------------------------
     // isSupported(TemporalField)
     //-----------------------------------------------------------------------
-    @Test()
-    public void basicTest_isSupported_TemporalField_supported() {
-        for (TemporalAccessor sample : samples()) {
-            for (TemporalField field : validFields()) {
-                assertEquals(true, sample.isSupported(field), "Failed on " + sample + " " + field);
-            }
+    @ParameterizedTest
+    @MethodSource("samples")
+    public void basicTest_isSupported_TemporalField_supported(TemporalAccessor sample) {
+        for (TemporalField field : validFields()) {
+            assertTrue(sample.isSupported(field), "Failed on " + sample + " " + field);
         }
     }
 
-    @Test()
-    public void basicTest_isSupported_TemporalField_unsupported() {
-        for (TemporalAccessor sample : samples()) {
-            for (TemporalField field : invalidFields()) {
-                assertEquals(false, sample.isSupported(field), "Failed on " + sample + " " + field);
-            }
+    @ParameterizedTest
+    @MethodSource("samples")
+    public void basicTest_isSupported_TemporalField_unsupported(TemporalAccessor sample) {
+        for (TemporalField field : invalidFields()) {
+            assertFalse(sample.isSupported(field), "Failed on " + sample + " " + field);
         }
     }
 
-    @Test()
-    public void basicTest_isSupported_TemporalField_null() {
-        for (TemporalAccessor sample : samples()) {
-            assertEquals(false, sample.isSupported(null), "Failed on " + sample);
-        }
+    @ParameterizedTest
+    @MethodSource("samples")
+    public void basicTest_isSupported_TemporalField_null(TemporalAccessor sample) {
+        assertFalse(sample.isSupported(null), "Failed on " + sample);
     }
 
     //-----------------------------------------------------------------------
     // range(TemporalField)
     //-----------------------------------------------------------------------
-    @Test()
-    public void basicTest_range_TemporalField_supported() {
-        for (TemporalAccessor sample : samples()) {
-            for (TemporalField field : validFields()) {
-                sample.range(field);  // no exception
-            }
+    @ParameterizedTest
+    @MethodSource("samples")
+    public void basicTest_range_TemporalField_supported(TemporalAccessor sample) {
+        for (TemporalField field : validFields()) {
+            assertDoesNotThrow(() -> sample.range(field));
         }
     }
 
-    @Test()
-    public void basicTest_range_TemporalField_unsupported() {
-        for (TemporalAccessor sample : samples()) {
-            for (TemporalField field : invalidFields()) {
-                try {
-                    sample.range(field);
-                    fail("Failed on " + sample + " " + field);
-                } catch (DateTimeException ex) {
-                    // expected
-                }
-            }
+    @ParameterizedTest
+    @MethodSource("samples")
+    public void basicTest_range_TemporalField_unsupported(TemporalAccessor sample) {
+        for (TemporalField field : invalidFields()) {
+            assertThrows(DateTimeException.class,
+                    () -> sample.range(field), "Failed on " + sample + " " + field);
         }
     }
 
-    @Test()
-    public void basicTest_range_TemporalField_null() {
-        for (TemporalAccessor sample : samples()) {
-            try {
-                sample.range(null);
-                fail("Failed on " + sample);
-            } catch (NullPointerException ex) {
-                // expected
-            }
-        }
+    @ParameterizedTest
+    @MethodSource("samples")
+    public void basicTest_range_TemporalField_null(TemporalAccessor sample) {
+        assertThrows(NullPointerException.class,
+                () -> sample.range(null), "Failed on " + sample);
     }
 
     //-----------------------------------------------------------------------
     // get(TemporalField)
     //-----------------------------------------------------------------------
-    @Test()
-    public void basicTest_get_TemporalField_supported() {
-        for (TemporalAccessor sample : samples()) {
-            for (TemporalField field : validFields()) {
-                if (sample.range(field).isIntValue()) {
-                    sample.get(field);  // no exception
-                } else {
-                    try {
-                        sample.get(field);
-                        fail("Failed on " + sample + " " + field);
-                    } catch (DateTimeException ex) {
-                        // expected
-                    }
-                }
+    @ParameterizedTest
+    @MethodSource("samples")
+    public void basicTest_get_TemporalField_supported(TemporalAccessor sample) {
+        for (TemporalField field : validFields()) {
+            if (sample.range(field).isIntValue()) {
+                assertDoesNotThrow(() -> sample.get(field));
+            } else {
+                assertThrows(DateTimeException.class,
+                        () -> sample.get(field), "Failed on " + sample + " " + field);
             }
         }
     }
 
-    @Test()
-    public void basicTest_get_TemporalField_unsupported() {
-        for (TemporalAccessor sample : samples()) {
-            for (TemporalField field : invalidFields()) {
-                try {
-                    sample.get(field);
-                    fail("Failed on " + sample + " " + field);
-                } catch (DateTimeException ex) {
-                    // expected
-                }
-            }
+    @ParameterizedTest
+    @MethodSource("samples")
+    public void basicTest_get_TemporalField_unsupported(TemporalAccessor sample) {
+        for (TemporalField field : invalidFields()) {
+            assertThrows(DateTimeException.class,
+                    () -> sample.get(field), "Failed on " + sample + " " + field);
         }
     }
 
-    @Test
-    public void test_get_TemporalField_invalidField() {
-        Assertions.assertThrows(DateTimeException.class, () -> {
-            for (TemporalAccessor sample : samples()) {
-                sample.get(MockFieldNoValue.INSTANCE);
-            }
-        });
+    @ParameterizedTest
+    @MethodSource("samples")
+    public void test_get_TemporalField_invalidField(TemporalAccessor sample) {
+        assertThrows(DateTimeException.class,
+                () -> sample.get(MockFieldNoValue.INSTANCE));
     }
 
-    @Test()
-    public void basicTest_get_TemporalField_null() {
-        for (TemporalAccessor sample : samples()) {
-            try {
-                sample.get(null);
-                fail("Failed on " + sample);
-            } catch (NullPointerException ex) {
-                // expected
-            }
-        }
+    @ParameterizedTest
+    @MethodSource("samples")
+    public void basicTest_get_TemporalField_null(TemporalAccessor sample) {
+        assertThrows(NullPointerException.class,
+                () -> sample.get(null), "Failed on " + sample);
     }
 
     //-----------------------------------------------------------------------
     // getLong(TemporalField)
     //-----------------------------------------------------------------------
-    @Test()
-    public void basicTest_getLong_TemporalField_supported() {
-        for (TemporalAccessor sample : samples()) {
-            for (TemporalField field : validFields()) {
-                sample.getLong(field);  // no exception
-            }
+    @ParameterizedTest
+    @MethodSource("samples")
+    public void basicTest_getLong_TemporalField_supported(TemporalAccessor sample) {
+        for (TemporalField field : validFields()) {
+            sample.getLong(field);
         }
     }
 
-    @Test()
-    public void basicTest_getLong_TemporalField_unsupported() {
-        for (TemporalAccessor sample : samples()) {
-            for (TemporalField field : invalidFields()) {
-                try {
-                    sample.getLong(field);
-                    fail("Failed on " + sample + " " + field);
-                } catch (DateTimeException ex) {
-                    // expected
-                }
-            }
+    @ParameterizedTest
+    @MethodSource("samples")
+    public void basicTest_getLong_TemporalField_unsupported(TemporalAccessor sample) {
+        for (TemporalField field : invalidFields()) {
+            assertThrows(DateTimeException.class,
+                    () -> sample.getLong(field), "Failed on " + sample + " " + field);
         }
     }
 
-    @Test
-    public void test_getLong_TemporalField_invalidField() {
-        Assertions.assertThrows(DateTimeException.class, () -> {
-            for (TemporalAccessor sample : samples()) {
-                sample.getLong(MockFieldNoValue.INSTANCE);
-            }
-        });
+    @ParameterizedTest
+    @MethodSource("samples")
+    public void test_getLong_TemporalField_invalidField(TemporalAccessor sample) {
+        assertThrows(DateTimeException.class,
+                () -> sample.getLong(MockFieldNoValue.INSTANCE));
     }
 
-    @Test()
-    public void basicTest_getLong_TemporalField_null() {
-        for (TemporalAccessor sample : samples()) {
-            try {
-                sample.getLong(null);
-                fail("Failed on " + sample);
-            } catch (NullPointerException ex) {
-                // expected
-            }
-        }
+    @ParameterizedTest
+    @MethodSource("samples")
+    public void basicTest_getLong_TemporalField_null(TemporalAccessor sample) {
+        assertThrows(NullPointerException.class,
+                () -> sample.getLong(null), "Failed on " + sample);
     }
 
     //-----------------------------------------------------------------------
-    @Test
-    public void basicTest_query() {
-        for (TemporalAccessor sample : samples()) {
-            assertEquals("foo", sample.query(new TemporalQuery<String>() {
-                @Override
-                public String queryFrom(TemporalAccessor temporal) {
-                    return "foo";
-                }
-            }));
-        }
+    @ParameterizedTest
+    @MethodSource("samples")
+    public void basicTest_query(TemporalAccessor sample) {
+        assertEquals("foo", sample.query(new TemporalQuery<String>() {
+            @Override
+            public String queryFrom(TemporalAccessor temporal) {
+                return "foo";
+            }
+        }));
     }
-
 }

--- a/test/jdk/java/time/tck/java/time/TCKInstant.java
+++ b/test/jdk/java/time/tck/java/time/TCKInstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -139,7 +139,8 @@ public class TCKInstant extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     @Override
     protected List<TemporalAccessor> samples() {
-        TemporalAccessor[] array = {TEST_12345_123456789, Instant.MIN, Instant.MAX, Instant.EPOCH};
+        TemporalAccessor[] array = {Instant.ofEpochSecond(12345, 123456789),
+                Instant.MIN, Instant.MAX, Instant.EPOCH};
         return Arrays.asList(array);
     }
 

--- a/test/jdk/java/time/tck/java/time/TCKLocalDate.java
+++ b/test/jdk/java/time/tck/java/time/TCKLocalDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,7 +170,7 @@ public class TCKLocalDate extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     @Override
     protected List<TemporalAccessor> samples() {
-        TemporalAccessor[] array = {TEST_2007_07_15, LocalDate.MAX, LocalDate.MIN, };
+        TemporalAccessor[] array = {LocalDate.of(2007, 7, 15), LocalDate.MAX, LocalDate.MIN, };
         return Arrays.asList(array);
     }
 

--- a/test/jdk/java/time/tck/java/time/TCKLocalTime.java
+++ b/test/jdk/java/time/tck/java/time/TCKLocalTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -161,7 +161,8 @@ public class TCKLocalTime extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     @Override
     protected List<TemporalAccessor> samples() {
-        TemporalAccessor[] array = {TEST_12_30_40_987654321, LocalTime.MIN, LocalTime.MAX, LocalTime.MIDNIGHT, LocalTime.NOON};
+        TemporalAccessor[] array = {LocalTime.of(12, 30, 40, 987654321),
+                LocalTime.MIN, LocalTime.MAX, LocalTime.MIDNIGHT, LocalTime.NOON};
         return Arrays.asList(array);
     }
 

--- a/test/jdk/java/time/tck/java/time/TCKMonthDay.java
+++ b/test/jdk/java/time/tck/java/time/TCKMonthDay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -118,7 +118,7 @@ public class TCKMonthDay extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     @Override
     protected List<TemporalAccessor> samples() {
-        TemporalAccessor[] array = {TEST_07_15, };
+        TemporalAccessor[] array = {MonthDay.of(7, 15), };
         return Arrays.asList(array);
     }
 

--- a/test/jdk/java/time/tck/java/time/TCKOffsetDateTime.java
+++ b/test/jdk/java/time/tck/java/time/TCKOffsetDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -167,7 +167,8 @@ public class TCKOffsetDateTime extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     @Override
     protected List<TemporalAccessor> samples() {
-        TemporalAccessor[] array = {TEST_2008_6_30_11_30_59_000000500, OffsetDateTime.MIN, OffsetDateTime.MAX};
+        TemporalAccessor[] array = {OffsetDateTime.of(2008, 6, 30, 11, 30, 59, 500, OFFSET_PONE),
+                OffsetDateTime.MIN, OffsetDateTime.MAX};
         return Arrays.asList(array);
     }
 

--- a/test/jdk/java/time/tck/java/time/TCKOffsetTime.java
+++ b/test/jdk/java/time/tck/java/time/TCKOffsetTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -149,7 +149,8 @@ public class TCKOffsetTime extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     @Override
     protected List<TemporalAccessor> samples() {
-        TemporalAccessor[] array = {TEST_11_30_59_500_PONE, OffsetTime.MIN, OffsetTime.MAX};
+        TemporalAccessor[] array = {OffsetTime.of(11, 30, 59, 500, OFFSET_PONE),
+                OffsetTime.MIN, OffsetTime.MAX};
         return Arrays.asList(array);
     }
 

--- a/test/jdk/java/time/tck/java/time/TCKYearMonth.java
+++ b/test/jdk/java/time/tck/java/time/TCKYearMonth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,7 +134,7 @@ public class TCKYearMonth extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     @Override
     protected List<TemporalAccessor> samples() {
-        TemporalAccessor[] array = {TEST_2008_06, };
+        TemporalAccessor[] array = {YearMonth.of(2008, 6), };
         return Arrays.asList(array);
     }
 

--- a/test/jdk/java/time/tck/java/time/TCKZonedDateTime.java
+++ b/test/jdk/java/time/tck/java/time/TCKZonedDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -176,7 +176,7 @@ public class TCKZonedDateTime extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     @Override
     protected List<TemporalAccessor> samples() {
-        TemporalAccessor[] array = {TEST_DATE_TIME, };
+        TemporalAccessor[] array = {ZonedDateTime.of(LocalDateTime.of(2008, 6, 30, 11, 30, 59, 500), ZONE_0100), };
         return Arrays.asList(array);
     }
 


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8374051](https://bugs.openjdk.org/browse/JDK-8374051) needs maintainer approval

### Issue
 * [JDK-8374051](https://bugs.openjdk.org/browse/JDK-8374051): Incorrect parameterized testing of exceptions in AbstractDateTimeTest.java (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/179/head:pull/179` \
`$ git checkout pull/179`

Update a local copy of the PR: \
`$ git checkout pull/179` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 179`

View PR using the GUI difftool: \
`$ git pr show -t 179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/179.diff">https://git.openjdk.org/jdk26u/pull/179.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/179#issuecomment-4303875279)
</details>
