### PR TITLE
8374322: TestMemoryWithSubgroups.java fails Permission denied

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
@@ -62,66 +62,48 @@ public class TestMemoryWithSubgroups {
         Common.prepareWhiteBox();
         DockerTestUtils.buildJdkContainerImage(imageName);
 
-        if ("cgroupv1".equals(metrics.getProvider())) {
-            try {
-                testMemoryLimitSubgroupV1("200m", "100m", "104857600", false);
-                testMemoryLimitSubgroupV1("1g", "500m", "524288000", false);
-                testMemoryLimitSubgroupV1("200m", "100m", "104857600", true);
-                testMemoryLimitSubgroupV1("1g", "500m", "524288000", true);
-            } finally {
-                DockerTestUtils.removeDockerImage(imageName);
-            }
-        } else if ("cgroupv2".equals(metrics.getProvider())) {
-            try {
-                testMemoryLimitSubgroupV2("200m", "100m", "104857600", false);
-                testMemoryLimitSubgroupV2("1g", "500m", "524288000", false);
-                testMemoryLimitSubgroupV2("200m", "100m", "104857600", true);
-                testMemoryLimitSubgroupV2("1g", "500m", "524288000", true);
-            } finally {
-                DockerTestUtils.removeDockerImage(imageName);
-            }
-        } else {
+        String provider = metrics.getProvider();
+        if (!"cgroupv1".equals(provider) && !"cgroupv2".equals(provider)) {
             throw new SkippedException("Metrics are from neither cgroup v1 nor v2, skipped for now.");
+        }
+
+        try {
+            testMemoryLimitSubgroup(provider, "200m", "100m", "104857600", false);
+            testMemoryLimitSubgroup(provider, "1g", "500m", "524288000", false);
+            testMemoryLimitSubgroup(provider, "200m", "100m", "104857600", true);
+            testMemoryLimitSubgroup(provider, "1g", "500m", "524288000", true);
+        } finally {
+            DockerTestUtils.removeDockerImage(imageName);
         }
     }
 
-    private static void testMemoryLimitSubgroupV1(String containerMemorySize, String valueToSet, String expectedValue, boolean privateNamespace)
+    private static void testMemoryLimitSubgroup(String cgroupVersion, String containerMemorySize,
+                                                String valueToSet, String expectedValue, boolean privateNamespace)
             throws Exception {
 
-        Common.logNewTestCase("Cgroup V1 subgroup memory limit: " + valueToSet);
+        final String upperVersion = "cgroupv1".equals(cgroupVersion) ? "V1" : "V2";
+        Common.logNewTestCase("Cgroup " + upperVersion + " subgroup memory limit: " + valueToSet);
 
         DockerRunOptions opts = new DockerRunOptions(imageName, "sh", "-c");
         opts.javaOpts = new ArrayList<>();
         opts.appendTestJavaOptions = false;
         opts.addDockerOpts("--privileged")
+            .addDockerOpts("--user", "root")
             .addDockerOpts("--cgroupns=" + (privateNamespace ? "private" : "host"))
             .addDockerOpts("--memory", containerMemorySize);
-        opts.addClassOptions("mkdir -p /sys/fs/cgroup/memory/test ; " +
-            "echo " + valueToSet + " > /sys/fs/cgroup/memory/test/memory.limit_in_bytes ; " +
-            "echo $$ > /sys/fs/cgroup/memory/test/cgroup.procs ; " +
-            "/jdk/bin/java -Xlog:os+container=trace -version");
-
-        Common.run(opts)
-            .shouldMatch("Lowest limit was:.*" + expectedValue);
-    }
-
-    private static void testMemoryLimitSubgroupV2(String containerMemorySize, String valueToSet, String expectedValue, boolean privateNamespace)
-            throws Exception {
-
-        Common.logNewTestCase("Cgroup V2 subgroup memory limit: " + valueToSet);
-
-        DockerRunOptions opts = new DockerRunOptions(imageName, "sh", "-c");
-        opts.javaOpts = new ArrayList<>();
-        opts.appendTestJavaOptions = false;
-        opts.addDockerOpts("--privileged")
-            .addDockerOpts("--cgroupns=" + (privateNamespace ? "private" : "host"))
-            .addDockerOpts("--memory", containerMemorySize);
-        opts.addClassOptions("mkdir -p /sys/fs/cgroup/memory/test ; " +
-            "echo $$ > /sys/fs/cgroup/memory/test/cgroup.procs ; " +
-            "echo '+memory' > /sys/fs/cgroup/cgroup.subtree_control ; " +
-            "echo '+memory' > /sys/fs/cgroup/memory/cgroup.subtree_control ; " +
-            "echo " + valueToSet + " > /sys/fs/cgroup/memory/test/memory.max ; " +
-            "/jdk/bin/java -Xlog:os+container=trace -version");
+        if ("cgroupv1".equals(cgroupVersion)) {
+            opts.addClassOptions("mkdir -p /sys/fs/cgroup/memory/test ; " +
+                "echo " + valueToSet + " > /sys/fs/cgroup/memory/test/memory.limit_in_bytes ; " +
+                "echo $$ > /sys/fs/cgroup/memory/test/cgroup.procs ; " +
+                "/jdk/bin/java -Xlog:os+container=trace -version");
+        } else {
+            opts.addClassOptions("mkdir -p /sys/fs/cgroup/memory/test ; " +
+                "echo $$ > /sys/fs/cgroup/memory/test/cgroup.procs ; " +
+                "echo '+memory' > /sys/fs/cgroup/cgroup.subtree_control ; " +
+                "echo '+memory' > /sys/fs/cgroup/memory/cgroup.subtree_control ; " +
+                "echo " + valueToSet + " > /sys/fs/cgroup/memory/test/memory.max ; " +
+                "/jdk/bin/java -Xlog:os+container=trace -version");
+        }
 
         Common.run(opts)
             .shouldMatch("Lowest limit was:.*" + expectedValue);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [18ac1723](https://github.com/openjdk/jdk/commit/18ac17236f29367ef2ee502436560e1832e28013) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 27 Apr 2026 and was reviewed by David Holmes and Afshin Zafari.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8374322](https://bugs.openjdk.org/browse/JDK-8374322) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8374322](https://bugs.openjdk.org/browse/JDK-8374322): TestMemoryWithSubgroups.java fails Permission denied (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/182/head:pull/182` \
`$ git checkout pull/182`

Update a local copy of the PR: \
`$ git checkout pull/182` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 182`

View PR using the GUI difftool: \
`$ git pr show -t 182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/182.diff">https://git.openjdk.org/jdk26u/pull/182.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/182#issuecomment-4323855455)
</details>
