### PR TITLE
8382740: JFR: Disable jdk.OldObjectSample event for generational ZGC

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/leakProfiler.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/leakProfiler.cpp
@@ -34,9 +34,15 @@
 #include "runtime/vmThread.hpp"
 
 bool LeakProfiler::is_supported() {
-  if (UseShenandoahGC) {
+  if (UseShenandoahGC || UseZGC) {
     // Leak Profiler uses mark words in the ways that might interfere
     // with concurrent GC uses of them. This affects Shenandoah.
+    //
+    // Generational ZGC only does weak reference processing in the old generation.
+    // All objects that would usually die, because we are sampling stuff
+    // that immediately becomes garbage, will be artificially kept alive
+    // until an old-generation collection. This incurs a significant
+    // performance hit by causing allocation stalls.
     return false;
   }
   return true;
@@ -58,7 +64,8 @@ bool LeakProfiler::start(int sample_count) {
 
   // Exit cleanly if not supported
   if (!is_supported()) {
-    log_trace(jfr, system)("Object sampling is not supported");
+    log_info(jfr, system)("jdk.OldObjectSample event is currently not supported for %s.",
+      UseShenandoahGC ? "ShenandoahGC" : "ZGC");
     return false;
   }
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -754,6 +754,7 @@ jdk/jfr/event/compiler/TestCodeSweeper.java                     8338127 generic-
 jdk/jfr/event/oldobject/TestShenandoah.java                     8342951 generic-all
 jdk/jfr/event/runtime/TestResidentSetSizeEvent.java             8309846 aix-ppc64
 jdk/jfr/jvm/TestWaste.java                                      8371630 generic-all
+jdk/jfr/event/oldobject/TestZ.java                              8375615 generic-all
 
 ############################################################################
 


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8382740](https://bugs.openjdk.org/browse/JDK-8382740) needs maintainer approval

### Issue
 * [JDK-8382740](https://bugs.openjdk.org/browse/JDK-8382740): JFR: Disable jdk.OldObjectSample event for generational ZGC (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/183/head:pull/183` \
`$ git checkout pull/183`

Update a local copy of the PR: \
`$ git checkout pull/183` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 183`

View PR using the GUI difftool: \
`$ git pr show -t 183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/183.diff">https://git.openjdk.org/jdk26u/pull/183.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/183#issuecomment-4328755568)
</details>
