### PR TITLE
8374943: TestDirectBufferStatisticsEvent failed with too few statistics events

### DIFF
--- a/test/jdk/jdk/jfr/event/runtime/TestDirectBufferStatisticsEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestDirectBufferStatisticsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 package jdk.jfr.event.runtime;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.List;
 
 import jdk.internal.misc.VM;
@@ -48,13 +49,14 @@ public class TestDirectBufferStatisticsEvent {
     private static final String EVENT_PATH = EventNames.DirectBufferStatistics;
 
     public static void main(String[] args) throws Throwable {
+        ArrayList<ByteBuffer> buffers = new ArrayList<>();
         try (Recording recording = new Recording()) {
             recording.enable(EVENT_PATH);
             recording.start();
             int rounds = 16;
             int size = 1 * 1024 * 1024; // 1M
             for (int i = 0; i < rounds; i++) {
-                ByteBuffer.allocateDirect(size);
+                buffers.add(ByteBuffer.allocateDirect(size));
             }
             recording.stop();
 


### PR DESCRIPTION
Hi all,

This backport PR fix the test bug which cause test intermittent fails. Change has been verified locally by run the test on linux-x64. Test-fix only, no risk.

Only the copyright year line conflict since file touched by '8374360: Update copyright year to 2025 for test/jdk/jdk/jfr in files where it was missed', and it's not suitable to backport it to jdk26u. All other parts are backport cleanly.

The commit being backported was authored by SendaoYan on 10 Apr 2026 and was reviewed by Erik Gahlin.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8374943](https://bugs.openjdk.org/browse/JDK-8374943) needs maintainer approval
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8374943](https://bugs.openjdk.org/browse/JDK-8374943): TestDirectBufferStatisticsEvent failed with too few statistics events (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/184/head:pull/184` \
`$ git checkout pull/184`

Update a local copy of the PR: \
`$ git checkout pull/184` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 184`

View PR using the GUI difftool: \
`$ git pr show -t 184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/184.diff">https://git.openjdk.org/jdk26u/pull/184.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/184#issuecomment-4332086208)
</details>
