### PR TITLE
8383570: Test DisabledAlgorithms.java intermittently timed out

### DIFF
--- a/test/jdk/javax/net/ssl/ciphersuites/DisabledAlgorithms.java
+++ b/test/jdk/javax/net/ssl/ciphersuites/DisabledAlgorithms.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,8 +36,10 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetAddress;
 import java.security.Security;
 import java.util.concurrent.TimeUnit;
+
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLServerSocket;
@@ -55,6 +57,8 @@ import javax.net.ssl.SSLSocketFactory;
  * that the handshake cannot complete successfully.
  */
 public class DisabledAlgorithms {
+
+    private static final int SOCKET_TIMEOUT_MILLIS = 10_000;
 
     public static final SSLContextTemplate.Cert[] CERTIFICATES = {
             SSLContextTemplate.Cert.EE_DSA_SHA1_1024,
@@ -139,15 +143,15 @@ public class DisabledAlgorithms {
         }
 
         switch (args[0]) {
-            case "default":
+            case "default" -> {
                 // use default jdk.tls.disabledAlgorithms
                 System.out.println("jdk.tls.disabledAlgorithms = "
                         + Security.getProperty("jdk.tls.disabledAlgorithms"));
 
                 // check that disabled cipher suites can't be used by default
                 checkFailure(DISABLED_CIPHERSUITES);
-                break;
-            case "empty":
+            }
+            case "empty" -> {
                 // reset jdk.tls.disabledAlgorithms
                 Security.setProperty("jdk.tls.disabledAlgorithms", "");
                 System.out.println("jdk.tls.disabledAlgorithms = "
@@ -162,9 +166,8 @@ public class DisabledAlgorithms {
                 // check that disabled cipher suites can be used if
                 // jdk.{tls,certpath}.disabledAlgorithms is empty
                 checkSuccess(DISABLED_CIPHERSUITES);
-                break;
-            default:
-                throw new RuntimeException("Wrong parameter: " + args[0]);
+            }
+            default -> throw new RuntimeException("Wrong parameter: " + args[0]);
         }
 
         System.out.println("Test passed");
@@ -270,7 +273,7 @@ public class DisabledAlgorithms {
                     DisabledAlgorithms.CERTIFICATES, getServerContextParameters());
             SSLServerSocketFactory ssf = context.getServerSocketFactory();
             SSLServerSocket ssocket = (SSLServerSocket)
-                    ssf.createServerSocket(0);
+                    ssf.createServerSocket(0, 0, InetAddress.getLoopbackAddress());
 
             if (ciphersuites != null) {
                 System.out.println("Server: enable cipher suites: "
@@ -287,7 +290,10 @@ public class DisabledAlgorithms {
             running = true;
             while (!stopped) {
                 try (SSLSocket socket = (SSLSocket) ssocket.accept()) {
-                    System.out.println("Server: accepted client connection");
+                    System.out.println("Server: accepted client connection from "
+                        + socket.getRemoteSocketAddress());
+                    socket.setSoTimeout(SOCKET_TIMEOUT_MILLIS);
+                    socket.startHandshake();
                     InputStream in = socket.getInputStream();
                     OutputStream out = socket.getOutputStream();
                     int b = in.read();
@@ -307,7 +313,6 @@ public class DisabledAlgorithms {
                                 + e);
                         e.printStackTrace();
                         otherError = true;
-                        stopped = true;
                     } else {
                         System.out.println("Server: run: " + e);
                         System.out.println("The exception above occurred "
@@ -367,7 +372,9 @@ public class DisabledAlgorithms {
             SSLContext context = createSSLContext(DisabledAlgorithms.CERTIFICATES,
                     null, getClientContextParameters());
             SSLSocketFactory ssf = context.getSocketFactory();
-            SSLSocket socket = (SSLSocket) ssf.createSocket("localhost", port);
+            SSLSocket socket = (SSLSocket) ssf.createSocket(
+                InetAddress.getLoopbackAddress(), port);
+            socket.setSoTimeout(SOCKET_TIMEOUT_MILLIS);
 
             if (ciphersuite != null) {
                 System.out.println("Client: enable cipher suite: "
@@ -379,6 +386,7 @@ public class DisabledAlgorithms {
 
         void connect() throws IOException {
             System.out.println("Client: connect to server");
+            socket.startHandshake();
             try (
                     BufferedInputStream bis = new BufferedInputStream(
                             socket.getInputStream());


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [f646ace3](https://github.com/openjdk/jdk/commit/f646ace39e8f0bb45081ee4679aac750caf91821) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 6 May 2026 and was reviewed by Daniel Jeliński.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8383570](https://bugs.openjdk.org/browse/JDK-8383570) needs maintainer approval
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8383570](https://bugs.openjdk.org/browse/JDK-8383570): Test DisabledAlgorithms.java intermittently timed out (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/191/head:pull/191` \
`$ git checkout pull/191`

Update a local copy of the PR: \
`$ git checkout pull/191` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 191`

View PR using the GUI difftool: \
`$ git pr show -t 191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/191.diff">https://git.openjdk.org/jdk26u/pull/191.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/191#issuecomment-4385587811)
</details>
