### PR TITLE
8377907: (process) Race in ProcessBuilder can cause JVM hangs

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,8 @@ ifeq ($(call isTargetOs, windows), true)
   BUILD_JDK_JTREG_EXCLUDE += libDirectIO.c libInheritedChannel.c \
       libExplicitAttach.c libImplicitAttach.c \
       exelauncher.c libFDLeaker.c exeFDLeakTester.c \
-      libChangeSignalDisposition.c exePrintSignalDisposition.c
+      libChangeSignalDisposition.c exePrintSignalDisposition.c \
+      libConcNativeFork.c libPipesCloseOnExec.c
 
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerTest := $(LIBCXX)
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exerevokeall := advapi32.lib
@@ -76,6 +77,9 @@ else
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libAsyncInvokers := -pthread
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerUnnamed := -pthread
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerModule := -pthread
+  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLoaderLookupInvoker := -pthread
+  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libConcNativeFork := -pthread
+  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libPipesCloseOnExec := -pthread
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLoaderLookupInvoker := -pthread
 
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libExplicitAttach := -pthread

--- a/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
+++ b/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,12 +26,13 @@
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/types.h>
-#include <sys/stat.h>
 
 #include "childproc.h"
 #include "childproc_errorcodes.h"
@@ -148,17 +149,37 @@ void initChildStuff (int fdin, int fdout, ChildStuff *c) {
     offset += sp.parentPathvBytes;
 }
 
+#ifdef DEBUG
+static void checkIsValid(int fd) {
+    if (!fdIsValid(fd)) {
+        puts(usageErrorText);
+        sendErrorCodeAndExit(-1, ESTEP_JSPAWN_INVALID_FD, fd, errno);
+    }
+}
+static void checkIsPipe(int fd) {
+    checkIsValid(fd);
+    if (!fdIsPipe(fd)) {
+        puts(usageErrorText);
+        sendErrorCodeAndExit(-1, ESTEP_JSPAWN_NOT_A_PIPE, fd, errno);
+    }
+}
+static void checkFileDescriptorSetup() {
+    checkIsValid(STDIN_FILENO);
+    checkIsValid(STDOUT_FILENO);
+    checkIsValid(STDERR_FILENO);
+    checkIsPipe(FAIL_FILENO);
+    checkIsPipe(CHILDENV_FILENO);
+}
+#endif // DEBUG
+
 int main(int argc, char *argv[]) {
     ChildStuff c;
-    struct stat buf;
-    /* argv[1] contains the fd number to read all the child info */
-    int r, fdinr, fdinw, fdout;
 
 #ifdef DEBUG
     jtregSimulateCrash(0, 4);
 #endif
 
-    if (argc != 3) {
+    if (argc != 2) {
         printf("Incorrect number of arguments: %d\n", argc);
         puts(usageErrorText);
         sendErrorCodeAndExit(-1, ESTEP_JSPAWN_ARG_ERROR, 0, 0);
@@ -170,32 +191,21 @@ int main(int argc, char *argv[]) {
         sendErrorCodeAndExit(-1, ESTEP_JSPAWN_VERSION_ERROR, 0, 0);
     }
 
-    r = sscanf (argv[2], "%d:%d:%d", &fdinr, &fdinw, &fdout);
-    if (r == 3 && fcntl(fdinr, F_GETFD) != -1 && fcntl(fdinw, F_GETFD) != -1) {
-        fstat(fdinr, &buf);
-        if (!S_ISFIFO(buf.st_mode)) {
-            printf("Incorrect input pipe\n");
-            puts(usageErrorText);
-            sendErrorCodeAndExit(-1, ESTEP_JSPAWN_NOT_A_PIPE, fdinr, errno);
-        }
-    } else {
-        printf("Incorrect FD array data: %s\n", argv[2]);
-        puts(usageErrorText);
-        sendErrorCodeAndExit(-1, ESTEP_JSPAWN_NOT_A_PIPE, fdinr, errno);
-    }
+#ifdef DEBUG
+    /* Check expected file descriptors */
+    checkFileDescriptorSetup();
+#endif
 
-    // Close the writing end of the pipe we use for reading from the parent.
-    // We have to do this before we start reading from the parent to avoid
-    // blocking in the case the parent exits before we finished reading from it.
-    close(fdinw); // Deliberately ignore errors (see https://lwn.net/Articles/576478/).
-    initChildStuff (fdinr, fdout, &c);
-    // Now set the file descriptor for the pipe's writing end to -1
-    // for the case that somebody tries to close it again.
-    assert(c.childenv[1] == fdinw);
-    c.childenv[1] = -1;
-    // The file descriptor for reporting errors back to our parent we got on the command
-    // line should be the same like the one in the ChildStuff struct we've just read.
-    assert(c.fail[1] == fdout);
+    initChildStuff(CHILDENV_FILENO, FAIL_FILENO, &c);
+
+#ifdef DEBUG
+    /* Not needed in spawn mode */
+    assert(c.in[0] == -1 && c.in[1] == -1 &&
+           c.out[0] == -1 && c.out[1] == -1 &&
+           c.err[0] == -1 && c.err[1] == -1 &&
+           c.fail[0] == -1 && c.fail[1] == -1 &&
+           c.fds[0] == -1 && c.fds[1] == -1 && c.fds[2] == -1);
+#endif
 
     childProcess (&c);
     return 0; /* NOT REACHED */

--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -43,7 +43,9 @@
 #include <sys/wait.h>
 #include <signal.h>
 #include <string.h>
-
+#include <fcntl.h>
+#include <stdbool.h>
+#include <unistd.h>
 #include <spawn.h>
 
 #include "childproc.h"
@@ -528,27 +530,46 @@ forkChild(ChildStuff *c) {
     return resultPid;
 }
 
+/* Given two fds, one of which has to be -1, the other one has to be valid,
+ * return the valid one. */
+static int eitherOneOf(int fd1, int fd2) {
+    if (fd2 == -1) {
+        assert(fdIsValid(fd1));
+        return fd1;
+    }
+    assert(fd1 == -1);
+    assert(fdIsValid(fd2));
+    return fd2;
+}
+
+static int call_posix_spawn_file_actions_adddup2(posix_spawn_file_actions_t *file_actions, int filedes, int newfiledes) {
+#ifdef __APPLE__
+    /* MacOS is not POSIX-compliant: dup2 file actions specifying the same fd as source and destination
+     * should be handled as no-op according to spec, but they cause EBADF. */
+    if (filedes == newfiledes) {
+        return 0;
+    }
+#endif
+    return posix_spawn_file_actions_adddup2(file_actions, filedes, newfiledes);
+}
+
 static pid_t
 spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) {
     pid_t resultPid;
-    int i, offset, rval, bufsize, magic;
-    char *buf, buf1[(3 * 11) + 3]; // "%d:%d:%d\0"
-    char *hlpargs[4];
+    int offset, rval, bufsize, magic;
+    char* buf;
+    char* hlpargs[3];
     SpawnInfo sp;
+    posix_spawn_file_actions_t file_actions;
+    int child_stdin, child_stdout, child_stderr, child_childenv, child_fail = -1;
 
-    /* need to tell helper which fd is for receiving the childstuff
-     * and which fd to send response back on
-     */
-    snprintf(buf1, sizeof(buf1), "%d:%d:%d", c->childenv[0], c->childenv[1], c->fail[1]);
     /* NULL-terminated argv array.
      * argv[0] contains path to jspawnhelper, to follow conventions.
      * argv[1] contains the version string as argument to jspawnhelper
-     * argv[2] contains the fd string as argument to jspawnhelper
      */
     hlpargs[0] = (char*)helperpath;
     hlpargs[1] = VERSION_STRING;
-    hlpargs[2] = buf1;
-    hlpargs[3] = NULL;
+    hlpargs[2] = NULL;
 
     /* Following items are sent down the pipe to the helper
      * after it is spawned.
@@ -571,19 +592,79 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
     bufsize += sp.dirlen;
     arraysize(parentPathv, &sp.nparentPathv, &sp.parentPathvBytes);
     bufsize += sp.parentPathvBytes;
-    /* We need to clear FD_CLOEXEC if set in the fds[].
-     * Files are created FD_CLOEXEC in Java.
-     * Otherwise, they will be closed when the target gets exec'd */
-    for (i=0; i<3; i++) {
-        if (c->fds[i] != -1) {
-            int flags = fcntl(c->fds[i], F_GETFD);
-            if (flags & FD_CLOEXEC) {
-                fcntl(c->fds[i], F_SETFD, flags & (~FD_CLOEXEC));
-            }
-        }
+
+    /* Prepare file descriptors for jspawnhelper and the target binary. */
+
+    /* 0: copy of either "in" pipe read fd or the stdin redirect fd */
+    child_stdin = eitherOneOf(c->fds[0], c->in[0]);
+
+    /* 1: copy of either "out" pipe write fd or the stdout redirect fd */
+    child_stdout = eitherOneOf(c->fds[1], c->out[1]);
+
+    /* 2: redirectErrorStream=1: redirected to child's stdout (Order matters!)
+     *    redirectErrorStream=0: copy of either "err" pipe write fd or stderr redirect fd. */
+    if (c->redirectErrorStream) {
+        child_stderr = STDOUT_FILENO; /* Note: this refers to the future stdout in the child process */
+    } else {
+        child_stderr = eitherOneOf(c->fds[2], c->err[1]);
     }
 
-    rval = posix_spawn(&resultPid, helperpath, 0, 0, (char * const *) hlpargs, environ);
+    /* 3: copy of the "fail" pipe write fd */
+    child_fail = c->fail[1];
+
+    /* 4: copy of the "childenv" pipe read end */
+    child_childenv = c->childenv[0];
+
+    assert(fdIsValid(child_stdin));
+    assert(fdIsValid(child_stdout));
+    assert(fdIsValid(child_stderr));
+    assert(fdIsPipe(child_fail));
+    assert(fdIsPipe(child_childenv));
+    /* This must always hold true, unless someone deliberately closed 0, 1, or 2 in the parent JVM. */
+    assert(child_fail > STDERR_FILENO);
+    assert(child_childenv > STDERR_FILENO);
+
+    /* Slot in dup2 file actions. */
+    posix_spawn_file_actions_init(&file_actions);
+
+#ifdef __APPLE__
+    /* On MacOS, posix_spawn does not behave in a POSIX-conform way in that the
+     * kernel closes CLOEXEC file descriptors too early for dup2 file actions to
+     * copy them after the fork. We have to explicitly prevent that by calling a
+     * propietary API. */
+    posix_spawn_file_actions_addinherit_np(&file_actions, child_stdin);
+    posix_spawn_file_actions_addinherit_np(&file_actions, child_stdout);
+    posix_spawn_file_actions_addinherit_np(&file_actions, child_stderr);
+    posix_spawn_file_actions_addinherit_np(&file_actions, child_fail);
+    posix_spawn_file_actions_addinherit_np(&file_actions, child_childenv);
+#endif
+
+    /* First dup2 stdin/out/err to 0,1,2. After this, we can safely dup2 over the
+     * original stdin/out/err. */
+    if (call_posix_spawn_file_actions_adddup2(&file_actions, child_stdin, STDIN_FILENO) != 0 ||
+        call_posix_spawn_file_actions_adddup2(&file_actions, child_stdout, STDOUT_FILENO) != 0 ||
+        /* Order matters: stderr may be redirected to stdout, so this dup2 must happen after the stdout one. */
+        call_posix_spawn_file_actions_adddup2(&file_actions, child_stderr, STDERR_FILENO) != 0)
+    {
+        return -1;
+    }
+
+    /* We dup2 with one intermediary step to prevent accidentally dup2'ing over child_childenv. */
+    const int tmp_child_childenv = child_fail < 10 ? 10 : child_fail - 1;
+    if (call_posix_spawn_file_actions_adddup2(&file_actions, child_childenv, tmp_child_childenv) != 0 ||
+        call_posix_spawn_file_actions_adddup2(&file_actions, child_fail, FAIL_FILENO) != 0 ||
+        call_posix_spawn_file_actions_adddup2(&file_actions, tmp_child_childenv, CHILDENV_FILENO) != 0)
+    {
+        return -1;
+    }
+
+    /* Since we won't use these in jspawnhelper, reset them all */
+    c->in[0] = c->in[1] = c->out[0] = c->out[1] =
+    c->err[0] = c->err[1] = c->fail[0] = c->fail[1] =
+    c->fds[0] = c->fds[1] = c->fds[2] = -1;
+    c->redirectErrorStream = false;
+
+    rval = posix_spawn(&resultPid, helperpath, &file_actions, 0, (char * const *) hlpargs, environ);
 
     if (rval != 0) {
         return -1;
@@ -667,6 +748,30 @@ startChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
     }
 }
 
+static int pipeSafely(int fd[2]) {
+    /* Pipe filedescriptors must be CLOEXEC as early as possible - ideally from the point of
+     * creation on - since at any moment a concurrent (third-party) fork() could inherit copies
+     * of these descriptors and accidentally keep the pipes open. That could cause the parent
+     * process to hang (see e.g. JDK-8377907).
+     * We use pipe2(2), if we have it. If we don't, we use pipe(2) + fcntl(2) immediately.
+     * The latter is still racy and can therefore still cause hangs as described in JDK-8377907,
+     * but at least the dangerous time window is as short as we can make it.
+     */
+    int rc = -1;
+#ifdef HAVE_PIPE2
+    rc = pipe2(fd, O_CLOEXEC);
+#else
+    rc = pipe(fd);
+    if (rc == 0) {
+        fcntl(fd[0], F_SETFD, FD_CLOEXEC);
+        fcntl(fd[1], F_SETFD, FD_CLOEXEC);
+    }
+#endif /* HAVE_PIPE2 */
+    assert(fdIsCloexec(fd[0]));
+    assert(fdIsCloexec(fd[1]));
+    return rc;
+}
+
 JNIEXPORT jint JNICALL
 Java_java_lang_ProcessImpl_forkAndExec(JNIEnv *env,
                                        jobject process,
@@ -727,11 +832,11 @@ Java_java_lang_ProcessImpl_forkAndExec(JNIEnv *env,
     fds = (*env)->GetIntArrayElements(env, std_fds, NULL);
     if (fds == NULL) goto Catch;
 
-    if ((fds[0] == -1 && pipe(in)  < 0) ||
-        (fds[1] == -1 && pipe(out) < 0) ||
-        (fds[2] == -1 && pipe(err) < 0) ||
-        (pipe(childenv) < 0) ||
-        (pipe(fail) < 0)) {
+    if ((fds[0] == -1 && pipeSafely(in)  < 0) ||
+        (fds[1] == -1 && pipeSafely(out) < 0) ||
+        (fds[2] == -1 && !redirectErrorStream && pipe(err) < 0) || // if not redirecting create the pipe
+        (pipeSafely(childenv) < 0) ||
+        (pipeSafely(fail) < 0)) {
         throwInternalIOException(env, errno, "Bad file descriptor", mode);
         goto Catch;
     }

--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -834,7 +834,7 @@ Java_java_lang_ProcessImpl_forkAndExec(JNIEnv *env,
 
     if ((fds[0] == -1 && pipeSafely(in)  < 0) ||
         (fds[1] == -1 && pipeSafely(out) < 0) ||
-        (fds[2] == -1 && !redirectErrorStream && pipe(err) < 0) || // if not redirecting create the pipe
+        (fds[2] == -1 && !redirectErrorStream && pipeSafely(err) < 0) || // if not redirecting create th        e pipe
         (pipeSafely(childenv) < 0) ||
         (pipeSafely(fail) < 0)) {
         throwInternalIOException(env, errno, "Bad file descriptor", mode);

--- a/src/java.base/unix/native/libjava/childproc.c
+++ b/src/java.base/unix/native/libjava/childproc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,13 +23,16 @@
  * questions.
  */
 
+#include <assert.h>
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include <limits.h>
 
@@ -39,12 +42,27 @@
 
 const char * const *parentPathv;
 
+#ifdef DEBUG
+bool fdIsValid(int fd) {
+    return fcntl(fd, F_GETFD) != -1;
+}
+bool fdIsPipe(int fd) {
+    struct stat buf;
+    errno = 0;
+    return fstat(fd, &buf) != -1 && S_ISFIFO(buf.st_mode);
+}
+bool fdIsCloexec(int fd) {
+    errno = 0;
+    const int flags = fcntl(fd, F_GETFD);
+    return flags != -1 && (flags & FD_CLOEXEC);
+}
+#endif // DEBUG
+
+static int
+restartableDup2(int fd_from, int fd_to, errcode_t* errcode)
 /* All functions taking an errcode_t* as output behave the same: upon error, they populate
  * errcode_t::hint and errcode_t::errno, but leave errcode_t::step as ESTEP_UNKNOWN since
  * this information will be provided by the outer caller */
-
-static bool
-restartableDup2(int fd_from, int fd_to, errcode_t* errcode)
 {
     int err;
     RESTARTABLE(dup2(fd_from, fd_to), err);
@@ -393,7 +411,10 @@ childProcess(void *arg)
 {
     const ChildStuff* p = (const ChildStuff*) arg;
 
-    int fail_pipe_fd = p->fail[1];
+    int fail_pipe_fd = (p->mode == MODE_POSIX_SPAWN) ?
+        FAIL_FILENO : /* file descriptors already set up by posix_spawn(). */
+        p->fail[1];
+
     /* error information for WhyCantJohnnyExec */
     errcode_t errcode;
 
@@ -407,55 +428,63 @@ childProcess(void *arg)
 #ifdef DEBUG
     jtregSimulateCrash(0, 6);
 #endif
-    /* Close the parent sides of the pipes.
-       Closing pipe fds here is redundant, since markDescriptorsCloseOnExec()
-       would do it anyways, but a little paranoia is a good thing. */
-    if (!closeSafely2(p->in[1], &errcode)  ||
-        !closeSafely2(p->out[0], &errcode) ||
-        !closeSafely2(p->err[0], &errcode) ||
-        !closeSafely2(p->childenv[0], &errcode) ||
-        !closeSafely2(p->childenv[1], &errcode) ||
-        !closeSafely2(p->fail[0], &errcode))
-    {
-        errcode.step = ESTEP_PIPECLOSE_FAIL;
-        goto WhyCantJohnnyExec;
-    }
 
-    /* Give the child sides of the pipes the right fileno's. */
-    /* Note: it is possible for in[0] == 0 */
-    if (!moveDescriptor(p->in[0] != -1 ?  p->in[0] : p->fds[0],
-                                STDIN_FILENO, &errcode)) {
-        errcode.step = ESTEP_DUP2_STDIN_FAIL;
-        goto WhyCantJohnnyExec;
-    }
+    /* File descriptor setup for non-Posix-spawn mode */
+    if (p->mode != MODE_POSIX_SPAWN) {
 
-    if (!moveDescriptor(p->out[1] != -1 ?  p->out[1] : p->fds[1],
-                                STDOUT_FILENO, &errcode)) {
-        errcode.step = ESTEP_DUP2_STDOUT_FAIL;
-        goto WhyCantJohnnyExec;
-    }
-
-    if (p->redirectErrorStream) {
-        if (!closeSafely2(p->err[1], &errcode) ||
-            !restartableDup2(STDOUT_FILENO, STDERR_FILENO, &errcode)) {
-            errcode.step = ESTEP_DUP2_STDERR_REDIRECT_FAIL;
+        /* Close the parent sides of the pipes.
+           Closing pipe fds here is redundant, since markDescriptorsCloseOnExec()
+           would do it anyways, but a little paranoia is a good thing. */
+        if (!closeSafely2(p->in[1], &errcode)  ||
+            !closeSafely2(p->out[0], &errcode) ||
+            !closeSafely2(p->err[0], &errcode) ||
+            !closeSafely2(p->childenv[0], &errcode) ||
+            !closeSafely2(p->childenv[1], &errcode) ||
+            !closeSafely2(p->fail[0], &errcode))
+        {
+            errcode.step = ESTEP_PIPECLOSE_FAIL;
             goto WhyCantJohnnyExec;
         }
-    } else {
-        if (!moveDescriptor(p->err[1] != -1 ? p->err[1] : p->fds[2],
-                                    STDERR_FILENO, &errcode)) {
-            errcode.step = ESTEP_DUP2_STDERR_REDIRECT_FAIL;
+
+        /* Give the child sides of the pipes the right fileno's. */
+        /* Note: it is possible for in[0] == 0 */
+        if (!moveDescriptor(p->in[0] != -1 ?  p->in[0] : p->fds[0],
+                                    STDIN_FILENO, &errcode)) {
+            errcode.step = ESTEP_DUP2_STDIN_FAIL;
             goto WhyCantJohnnyExec;
         }
-    }
 
-    if (!moveDescriptor(fail_pipe_fd, FAIL_FILENO, &errcode)) {
-        errcode.step = ESTEP_DUP2_FAILPIPE_FAIL;
-        goto WhyCantJohnnyExec;
-    }
+        if (!moveDescriptor(p->out[1] != -1 ?  p->out[1] : p->fds[1],
+                                    STDOUT_FILENO, &errcode)) {
+            errcode.step = ESTEP_DUP2_STDOUT_FAIL;
+            goto WhyCantJohnnyExec;
+        }
 
-    /* We moved the fail pipe fd */
-    fail_pipe_fd = FAIL_FILENO;
+        if (p->redirectErrorStream) {
+            if (!closeSafely2(p->err[1], &errcode) ||
+                !restartableDup2(STDOUT_FILENO, STDERR_FILENO, &errcode)) {
+                errcode.step = ESTEP_DUP2_STDERR_REDIRECT_FAIL;
+                goto WhyCantJohnnyExec;
+            }
+        } else {
+            if (!moveDescriptor(p->err[1] != -1 ? p->err[1] : p->fds[2],
+                                        STDERR_FILENO, &errcode)) {
+                errcode.step = ESTEP_DUP2_STDERR_REDIRECT_FAIL;
+                goto WhyCantJohnnyExec;
+            }
+        }
+
+        if (!moveDescriptor(fail_pipe_fd, FAIL_FILENO, &errcode)) {
+            errcode.step = ESTEP_DUP2_FAILPIPE_FAIL;
+            goto WhyCantJohnnyExec;
+        }
+
+        /* We moved the fail pipe fd */
+        fail_pipe_fd = FAIL_FILENO;
+
+    } /* end: FORK/VFORK mode */
+
+    assert(fail_pipe_fd == FAIL_FILENO);
 
     /* For AIX: The code in markDescriptorsCloseOnExec() relies on the current
      * semantic of this function. When this point here is reached only the

--- a/src/java.base/unix/native/libjava/childproc.h
+++ b/src/java.base/unix/native/libjava/childproc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
 #define CHILDPROC_MD_H
 
 #include <sys/types.h>
+#include <stdbool.h>
 
 #ifdef __APPLE__
 #include <crt_externs.h>
@@ -71,6 +72,9 @@ extern char **environ;
 #endif
 
 #define FAIL_FILENO (STDERR_FILENO + 1)
+
+/* For POSIX_SPAWN mode */
+#define CHILDENV_FILENO (FAIL_FILENO + 1)
 
 /* These numbers must be the same as the Enum in ProcessImpl.java
  * Must be a better way of doing this.
@@ -129,6 +133,17 @@ int childProcess(void *arg);
  * See: test/jdk/java/lang/ProcessBuilder/JspawnhelperProtocol.java
  */
 void jtregSimulateCrash(pid_t child, int stage);
+/* Helper functions to check the state of fds */
+bool fdIsValid(int fd);
+bool fdIsPipe(int fd);
+bool fdIsCloexec(int fd);
 #endif
 
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#define HAVE_PIPE2
+#else
+// Neither MacOS nor AIX support pipe2, unfortunately
+#undef HAVE_PIPE2
 #endif
+
+#endif /* CHILDPROC_MD_H */

--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -22,13 +22,13 @@
  */
 
 /*
- * @test
+ * @test id=POSIX_SPAWN
  * @bug 4199068 4738465 4937983 4930681 4926230 4931433 4932663 4986689
  *      5026830 5023243 5070673 4052517 4811767 6192449 6397034 6413313
  *      6464154 6523983 6206031 4960438 6631352 6631966 6850957 6850958
  *      4947220 7018606 7034570 4244896 5049299 8003488 8054494 8058464
  *      8067796 8224905 8263729 8265173 8272600 8231297 8282219 8285517
- *      8352533 8368192
+ *      8352533 8368192 8377907
  * @key intermittent
  * @summary Basic tests for Process and Environment Variable code
  * @modules java.base/java.lang:open
@@ -36,19 +36,30 @@
  * @requires !vm.musl
  * @requires vm.flagless
  * @library /test/lib
- * @run main/othervm/native/timeout=360 Basic
- * @run main/othervm/native/timeout=360 -Djdk.lang.Process.launchMechanism=fork Basic
+ * @run main/othervm/native/timeout=360 -Djdk.lang.Process.launchMechanism=posix_spawn Basic
  * @author Martin Buchholz
  */
 
 /*
- * @test
+ * @test id=FORK
+ * @key intermittent
+ * @summary Basic tests for Process and Environment Variable code
+ * @modules java.base/java.lang:open
+ *          java.base/java.io:open
+ * @requires !vm.musl
+ * @requires vm.flagless
+ * @library /test/lib
+ * @run main/othervm/native/timeout=360 -Djdk.lang.Process.launchMechanism=fork Basic
+ */
+
+/*
+ * @test id=VFORK
  * @modules java.base/java.lang:open
  *          java.base/java.io:open
  *          java.base/jdk.internal.misc
  * @requires (os.family == "linux" & !vm.musl)
  * @library /test/lib
- * @run main/othervm/timeout=300 -Djdk.lang.Process.launchMechanism=posix_spawn Basic
+ * @run main/othervm/timeout=300 -Djdk.lang.Process.launchMechanism=vfork Basic
  */
 
 import java.lang.ProcessBuilder.Redirect;
@@ -1230,6 +1241,20 @@ public class Basic {
             equal(r.out(), "standard output");
             equal(r.err(), "standard error");
         }
+
+        //----------------------------------------------------------------
+        // Default: should go to pipes (use a fresh ProcessBuilder)
+        //----------------------------------------------------------------
+        {
+            ProcessBuilder pb2 = new ProcessBuilder(childArgs);
+            Process p = pb2.start();
+            new PrintStream(p.getOutputStream()).print("standard input");
+            p.getOutputStream().close();
+            ProcessResults r = run(p);
+            equal(r.exitValue(), 0);
+            equal(r.out, "standard output");
+            equal(r.err, "standard error");
+        }
     }
 
     static void checkProcessPid() {
@@ -1267,6 +1292,8 @@ public class Basic {
             System.out.println("This appears to be a Unix system.");
         if (UnicodeOS.is())
             System.out.println("This appears to be a Unicode-based OS.");
+
+        System.out.println("Using:" + System.getProperty("jdk.lang.Process.launchMechanism"));
 
         try { testIORedirection(); }
         catch (Throwable t) { unexpected(t); }

--- a/test/jdk/java/lang/ProcessBuilder/ConcNativeForkTest/ConcNativeForkTest.java
+++ b/test/jdk/java/lang/ProcessBuilder/ConcNativeForkTest/ConcNativeForkTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, IBM Corp.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=POSIX_SPAWN
+ * @bug 8377907
+ * @summary Test that demonstrates the hanging-parent-on-native-concurrent-forks problem
+ * @requires os.family != "windows"
+ * @requires vm.flagless
+ * @library /test/lib
+ * @run main/othervm/manual -Djdk.lang.Process.launchMechanism=POSIX_SPAWN ConcNativeForkTest
+ */
+
+/*
+ * @test id=FORK
+ * @bug 8377907
+ * @summary Test that demonstrates the hanging-parent-on-native-concurrent-forks problem
+ * @requires os.family != "windows"
+ * @requires vm.flagless
+ * @library /test/lib
+ * @run main/othervm/manual -Djdk.lang.Process.launchMechanism=FORK ConcNativeForkTest
+ */
+
+/*
+ * @test id=VFORK
+ * @bug 8377907
+ * @summary Test that demonstrates the hanging-parent-on-native-concurrent-forks problem
+ * @requires os.family == "linux"
+ * @requires vm.flagless
+ * @library /test/lib
+ * @run main/othervm/manual -Djdk.lang.Process.launchMechanism=VFORK ConcNativeForkTest
+ */
+
+public class ConcNativeForkTest {
+
+    // How this works:
+    // - We start a child process via ProcessBuilder. Does not matter what, we just call "/bin/true".
+    // - Concurrently, we continuously (up to a limit) fork natively; these forks will all exec "sleep 30".
+    // - If the natively forked child process forks off at the right (wrong) moment, it will catch the open pipe from
+    //   the "/bin/true" child process, and forcing the parent process (this test) to wait in ProcessBuilder.start()
+    //   (inside forkAndExec()) until the natively forked child releases the pipe file descriptors it inherited.
+
+    // Notes:
+    //
+    // Obviously, this is racy and depends on scheduler timings of the underlying OS. The test succeeding is
+    // no proof the bug does not exist (see PipesCloseOnExecTest as a complimentary test that is more reliable, but
+    // only works on Linux).
+    // That said, in tests it reliably reproduces the bug on Linux x64 and MacOS Arm.
+    //
+    // This test is not well suited for automatic test execution, since the test essentially
+    // fork-bombs itself, and that may run into issues in containerized CI/CD environments.
+
+    native static boolean prepareNativeForkerThread(int numForks);
+    native static void releaseNativeForkerThread();
+    native static void stopNativeForkerThread();
+
+    private static final int numIterations = 20;
+
+    public static void main(String[] args) throws Exception {
+
+        System.out.println("jdk.lang.Process.launchMechanism=" +
+                System.getProperty("jdk.lang.Process.launchMechanism"));
+
+        System.loadLibrary("ConcNativeFork");
+
+        // A very simple program returning immediately (/bin/true)
+        ProcessBuilder pb = new ProcessBuilder("true").inheritIO();
+        final int numJavaProcesses = 10;
+        final int numNativeProcesses = 250;
+        Process[] processes = new Process[numJavaProcesses];
+
+        for (int iteration = 0; iteration < numIterations; iteration ++) {
+
+            if (!prepareNativeForkerThread(numNativeProcesses)) {
+                throw new RuntimeException("Failed to start native forker thread (see stdout)");
+            }
+
+            long[] durations = new long[numJavaProcesses];
+
+            releaseNativeForkerThread();
+
+            for (int np = 0; np < numJavaProcesses; np ++) {
+                long t1 = System.currentTimeMillis();
+                try (Process p = pb.start()) {
+                    durations[np] = System.currentTimeMillis() - t1;
+                    processes[np] = p;
+                }
+            }
+
+            stopNativeForkerThread();
+
+            long longestDuration = 0;
+            for (int np = 0; np < numJavaProcesses; np ++) {
+                processes[np].waitFor();
+                System.out.printf("Duration: %dms%n", durations[np]);
+                longestDuration = Math.max(durations[np], longestDuration);
+            }
+
+            System.out.printf("Longest startup time: %dms%n", longestDuration);
+
+            if (longestDuration >= 30000) {
+                throw new RuntimeException("Looks like we blocked on native fork");
+            }
+        }
+
+    }
+
+}

--- a/test/jdk/java/lang/ProcessBuilder/ConcNativeForkTest/libConcNativeFork.c
+++ b/test/jdk/java/lang/ProcessBuilder/ConcNativeForkTest/libConcNativeFork.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, IBM Corp.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdatomic.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <jni.h>
+#include "testlib_thread_barriers.h"
+
+static void trc(const char* fmt, ...) {
+    char buf [1024];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+    printf("(pid: %d): %s\n", (int)getpid(), buf);
+    fflush(stdout);
+}
+
+static pthread_t tid_forker;
+
+static pthread_barrier_t start_barrier;
+static atomic_bool stop_now = false;
+
+static void* forkerLoop(void* info) {
+
+    const int numForks = (int)(intptr_t)info;
+    pid_t* pids = calloc(numForks, sizeof(pid_t));
+
+    trc("Forker: Waiting for Go.");
+
+    pthread_barrier_wait(&start_barrier);
+
+    for (int i = 0; i < numForks; i++) {
+        const pid_t pid = fork();
+        if (pid == 0) {
+            /* Exec sleep. Properly opened file descriptors in parents (tagged CLOEXEC) should be released now.
+             * Note that we use bash to not have to deal with path resolution. For our case, it does not matter if
+             * sleep is a builtin or not. */
+            char* env[] = { "PATH=/usr/bin:/bin", NULL };
+            char* argv[] = { "sh", "-c", "sleep 30", NULL };
+            execve("/bin/sh", argv, env);
+            trc("Native child: sleep exec failed? %d", errno);
+            /* The simplest way to handle this is to just wait here; this *will* cause the test to fail. */
+            sleep(120);
+            trc("Native child: exiting");
+            exit(0);
+        } else {
+            pids[i] = pid;
+            sched_yield();
+        }
+    }
+
+    trc("Forker: All native child processes started.");
+
+    /* Wait for test to signal end */
+    while (!atomic_load(&stop_now)) {
+        sleep(1);
+    }
+
+    trc("Forker: Cleaning up.");
+
+    /* Reap children */
+    for (int i = 0; i < numForks; i ++) {
+        if (pids[i] != 0) {
+            kill(pids[i], SIGKILL); /* if still running */
+            waitpid(pids[i], NULL, 0);
+        }
+    }
+
+    trc("Forker: Done.");
+
+    return NULL;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_ConcNativeForkTest_prepareNativeForkerThread(JNIEnv* env, jclass cls, jint numForks)
+{
+    pthread_attr_t attr;
+    int rc = 0;
+
+    const int cap = 1000;
+    const int numForksCapped = numForks > cap ? cap : numForks;
+    if (numForks > numForksCapped) {
+        trc("Main: Capping max. number of forks at %d", numForksCapped); /* don't forkbomb me */
+    }
+
+    if (pthread_barrier_init(&start_barrier, NULL, 2) != 0) {
+        trc("Main: pthread_barrier_init failed (%d)", errno);
+        return false;
+    }
+
+    pthread_attr_init(&attr);
+    if (pthread_create(&tid_forker, &attr, forkerLoop, (void*)(intptr_t)numForksCapped) != 0) {
+        trc("Main: pthread_create failed (%d)", errno);
+        return JNI_FALSE;
+    }
+
+    trc("Main: Prepared native forker thread");
+
+    return JNI_TRUE;
+}
+
+JNIEXPORT void JNICALL
+Java_ConcNativeForkTest_releaseNativeForkerThread(JNIEnv* env, jclass cls)
+{
+    pthread_barrier_wait(&start_barrier);
+    trc("Main: signaled GO");
+}
+
+JNIEXPORT void JNICALL
+Java_ConcNativeForkTest_stopNativeForkerThread(JNIEnv* env, jclass cls)
+{
+    atomic_store(&stop_now, true);
+    pthread_join(tid_forker, NULL);
+    pthread_barrier_destroy(&start_barrier);
+}

--- a/test/jdk/java/lang/ProcessBuilder/FDLeakTest/FDLeakTest.java
+++ b/test/jdk/java/lang/ProcessBuilder/FDLeakTest/FDLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 
 /**
  * @test id=posix_spawn
- * @summary Check that we don't leak FDs
+ * @summary Check that we don't leak FDs to child processes
  * @requires os.family != "windows"
  * @library /test/lib
  * @run main/othervm/native -Djdk.lang.Process.launchMechanism=posix_spawn -agentlib:FDLeaker FDLeakTest
@@ -32,7 +32,7 @@
 
 /**
  * @test id=fork
- * @summary Check that we don't leak FDs
+ * @summary Check that we don't leak FDs to child processes
  * @requires os.family != "windows"
  * @library /test/lib
  * @run main/othervm/native -Djdk.lang.Process.launchMechanism=fork -agentlib:FDLeaker FDLeakTest
@@ -40,7 +40,7 @@
 
 /**
  * @test id=vfork
- * @summary Check that we don't leak FDs
+ * @summary Check that we don't leak FDs to child processes
  * @requires os.family == "linux"
  * @library /test/lib
  * @run main/othervm/native -Djdk.lang.Process.launchMechanism=vfork -agentlib:FDLeaker FDLeakTest

--- a/test/jdk/java/lang/ProcessBuilder/JspawnhelperWarnings.java
+++ b/test/jdk/java/lang/ProcessBuilder/JspawnhelperWarnings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ public class JspawnhelperWarnings {
         oa.shouldHaveExitValue(EXITCODE_OFFSET + ESTEP_JSPAWN_ARG_ERROR);
         oa.shouldContain("jspawnhelper fail: (1-0-0)");
         oa.shouldContain("This command is not for general use");
-        if (nArgs != 2) {
+        if (nArgs != 1) {
             oa.shouldContain("Incorrect number of arguments");
         } else {
             oa.shouldContain("Incorrect Java version");
@@ -69,10 +69,9 @@ public class JspawnhelperWarnings {
     }
 
     private static void testVersion() throws Exception {
-        String[] args = new String[3];
+        String[] args = new String[2];
         args[0] = Paths.get(System.getProperty("java.home"), "lib", "jspawnhelper").toString();
         args[1] = "wrongVersion";
-        args[2] = "1:1:1";
         Process p = ProcessTools.startProcess("jspawnhelper", new ProcessBuilder(args));
         OutputAnalyzer oa = new OutputAnalyzer(p);
         oa.shouldHaveExitValue(EXITCODE_OFFSET + ESTEP_JSPAWN_VERSION_ERROR);
@@ -88,7 +87,7 @@ public class JspawnhelperWarnings {
         switch (args[0]) {
             case "badargs" -> {
                 for (int nArgs = 0; nArgs < 10; nArgs++) {
-                    if (nArgs != 2) {
+                    if (nArgs != 1) {
                         tryWithNArgs(nArgs);
                     }
                 }

--- a/test/jdk/java/lang/ProcessBuilder/NonPipelineLeaksFD.java
+++ b/test/jdk/java/lang/ProcessBuilder/NonPipelineLeaksFD.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, IBM Corp.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.*;
+
+/*
+ * @test id=FORK
+ * @summary Check that we don't accumulate leaked FDs in the parent process
+ * @requires os.family == "linux"
+ * @library /test/lib
+ * @run main/othervm -Djdk.lang.Process.launchMechanism=fork NonPipelineLeaksFD
+ */
+
+/*
+ * @test id=VFORK
+ * @summary Check that we don't accumulate leaked FDs in the parent process
+ * @requires os.family == "linux"
+ * @library /test/lib
+ * @run main/othervm -Djdk.lang.Process.launchMechanism=vfork NonPipelineLeaksFD
+ */
+
+/*
+ * @test id=POSIX_SPAWN
+ * @summary Check that we don't accumulate leaked FDs in the parent process
+ * @requires os.family == "linux"
+ * @library /test/lib
+ * @run main/othervm -Djdk.lang.Process.launchMechanism=posix_spawn NonPipelineLeaksFD
+ */
+
+public class NonPipelineLeaksFD {
+
+    final static int repeatCount = 50;
+
+    // Similar to PilelineLeaksFD, but where PilelineLeaksFD checks that the parent process
+    // does not leak file descriptors when invoking a pipeline, here we check that we don't
+    // leak FDs when executing simple (non-pipelined) programs but we test a wider span of
+    // redirection modes in both successful and failing variants.
+
+    // How this works:
+    //
+    // We execute a mix of failing and succeeding child process starts with various
+    // flavors of IO redirections many times; we observe the open file descriptors
+    // before and afterwards. Test fails if we have significantly more file descriptors
+    // open afterwards than before.
+
+    static int countNumberOfOpenFileDescriptors() {
+        return new File("/proc/self/fd").list().length;
+    }
+
+    static void printOpenFileDescriptors() {
+        long mypid =  ProcessHandle.current().pid();
+        try(Process p = new ProcessBuilder("lsof", "-p", Long.toString(mypid))
+                .inheritIO().start()) {
+            p.waitFor();
+        } catch (InterruptedException | IOException ignored) {
+            // Quietly swallow; it was just an attempt.
+        }
+    }
+
+    static String readFirstLineOf(File f) {
+        String result;
+        try (BufferedReader b = new BufferedReader(new FileReader(f))){
+            result = b.readLine();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return result;
+    }
+
+    static void runThisExpectSuccess(ProcessBuilder bld) {
+        try(Process p = bld.start()) {
+            p.waitFor();
+            if (p.exitValue() != 0) {
+                throw new RuntimeException("Unexpected exitcode");
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static void runThisExpectError(ProcessBuilder bld) {
+        boolean failed = false;
+        try(Process p = bld.start()) {
+            p.waitFor();
+        } catch (IOException | InterruptedException e) {
+            failed = true;
+        }
+        if (!failed) {
+            throw new RuntimeException("Expected Error");
+        }
+    }
+
+    static void runPosWithPipes() {
+        ProcessBuilder bld = new ProcessBuilder("sh", "-c", "echo hallo");
+        runThisExpectSuccess(bld);
+    }
+
+    static void runPosWithInheritIO() {
+        ProcessBuilder bld = new ProcessBuilder("sh", "-c", "echo hallo").inheritIO();
+        runThisExpectSuccess(bld);
+    }
+
+    static void runPosWithRedirectToFile() {
+        File fo = new File("test.out");
+        ProcessBuilder bld = new ProcessBuilder("sh", "-c", "echo hallo");
+        bld.redirectOutput(ProcessBuilder.Redirect.to(fo));
+        runThisExpectSuccess(bld);
+        if (!readFirstLineOf(fo).equals("hallo")) {
+            throw new RuntimeException("mismatch");
+        }
+    }
+
+    static void runNegWithPipes() {
+        ProcessBuilder bld = new ProcessBuilder("doesnotexist");
+        runThisExpectError(bld);
+    }
+
+    static void runNegWithInheritIO() {
+        ProcessBuilder bld = new ProcessBuilder("doesnotexist").inheritIO();
+        runThisExpectError(bld);
+    }
+
+    static void runNegWithRedirectToFile() {
+        File fo = new File("test.out");
+        ProcessBuilder bld = new ProcessBuilder("doesnotexist");
+        bld.redirectOutput(ProcessBuilder.Redirect.to(fo));
+        runThisExpectError(bld);
+    }
+
+    static void doTestNTimesAndCountFDs(Runnable runnable, String name) {
+        System.out.println(name);
+        int c1 = countNumberOfOpenFileDescriptors();
+        for (int i = 0; i < repeatCount; i++) {
+            runnable.run();
+        }
+        int c2 = countNumberOfOpenFileDescriptors();
+        System.out.printf("%d->%d", c1, c2);
+    }
+
+    public static void main(String[] args) throws Exception {
+        System.out.println("jdk.lang.Process.launchMechanism=" +
+                System.getProperty("jdk.lang.Process.launchMechanism"));
+        int c1 = countNumberOfOpenFileDescriptors();
+        doTestNTimesAndCountFDs(NonPipelineLeaksFD::runPosWithPipes, "runPosWithPipes");
+        doTestNTimesAndCountFDs(NonPipelineLeaksFD::runPosWithInheritIO, "runPosWithInheritIO");
+        doTestNTimesAndCountFDs(NonPipelineLeaksFD::runPosWithRedirectToFile, "runPosWithRedirectToFile");
+        doTestNTimesAndCountFDs(NonPipelineLeaksFD::runNegWithPipes, "runNegWithPipes");
+        doTestNTimesAndCountFDs(NonPipelineLeaksFD::runNegWithInheritIO, "runNegWithInheritIO");
+        doTestNTimesAndCountFDs(NonPipelineLeaksFD::runNegWithRedirectToFile, "runNegWithRedirectToFile");
+        int c2 = countNumberOfOpenFileDescriptors();
+
+        System.out.printf("All tests: %d->%d", c1, c2);
+        printOpenFileDescriptors();
+
+        final int fudge = 10;
+        if (c2 > (c1 + fudge)) {
+            throw new RuntimeException(
+                    String.format("Leak suspected (%d->%d) - see lsof output", c1, c2));
+        }
+    }
+}

--- a/test/jdk/java/lang/ProcessBuilder/PipelineLeaksFD.java
+++ b/test/jdk/java/lang/ProcessBuilder/PipelineLeaksFD.java
@@ -38,7 +38,7 @@ import java.util.Set;
 /*
  * @test id=FORK
  * @bug 8289643 8291760
- * @requires os.family == "mac" | (os.family == "linux" & !vm.musl)
+ * @requires (os.family == "linux" & !vm.musl)
  * @summary File descriptor leak detection with ProcessBuilder.startPipeline
  * @run testng/othervm -Djdk.lang.Process.launchMechanism=FORK PipelineLeaksFD
  */
@@ -46,7 +46,7 @@ import java.util.Set;
 /*
  * @test id=POSIX_SPAWN
  * @bug 8289643 8291760
- * @requires os.family == "mac" | (os.family == "linux" & !vm.musl)
+ * @requires (os.family == "linux" & !vm.musl)
  * @summary File descriptor leak detection with ProcessBuilder.startPipeline
  * @run testng/othervm -Djdk.lang.Process.launchMechanism=POSIX_SPAWN PipelineLeaksFD
  */

--- a/test/jdk/java/lang/ProcessBuilder/PipelineLeaksFD.java
+++ b/test/jdk/java/lang/ProcessBuilder/PipelineLeaksFD.java
@@ -36,11 +36,19 @@ import java.util.List;
 import java.util.Set;
 
 /*
- * @test
+ * @test id=FORK
  * @bug 8289643 8291760
- * @requires (os.family == "linux" & !vm.musl)
+ * @requires os.family == "mac" | (os.family == "linux" & !vm.musl)
  * @summary File descriptor leak detection with ProcessBuilder.startPipeline
- * @run testng/othervm PipelineLeaksFD
+ * @run testng/othervm -Djdk.lang.Process.launchMechanism=FORK PipelineLeaksFD
+ */
+
+/*
+ * @test id=POSIX_SPAWN
+ * @bug 8289643 8291760
+ * @requires os.family == "mac" | (os.family == "linux" & !vm.musl)
+ * @summary File descriptor leak detection with ProcessBuilder.startPipeline
+ * @run testng/othervm -Djdk.lang.Process.launchMechanism=POSIX_SPAWN PipelineLeaksFD
  */
 
 @Test
@@ -63,6 +71,8 @@ public class PipelineLeaksFD {
     void checkForLeaks(List<ProcessBuilder> builders) throws IOException {
 
         Set<PipeRecord> pipesBefore = myPipes();
+
+        System.out.println("Using:" + System.getProperty("jdk.lang.Process.launchMechanism"));
         if (pipesBefore.size() < 3) {
             System.out.println(pipesBefore);
             Assert.fail("There should be at least 3 pipes before, (0, 1, 2)");

--- a/test/jdk/java/lang/ProcessBuilder/PipesCloseOnExecTest/PipesCloseOnExecTest.java
+++ b/test/jdk/java/lang/ProcessBuilder/PipesCloseOnExecTest/PipesCloseOnExecTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, IBM Corp.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=FORK
+ * @bug 8377907
+ * @summary Check that we don't open pipes without CLOEXCEC
+ * @requires os.family == "linux"
+ * @requires vm.flagless
+ * @library /test/lib
+ * @run main/othervm/native -Djdk.lang.Process.launchMechanism=FORK PipesCloseOnExecTest
+ */
+
+/*
+ * @test id=VFORK
+ * @bug 8377907
+ * @summary Check that we don't open pipes without CLOEXCEC
+ * @requires os.family == "linux"
+ * @requires vm.flagless
+ * @library /test/lib
+ * @run main/othervm/native -Djdk.lang.Process.launchMechanism=VFORK PipesCloseOnExecTest
+ */
+
+/*
+ * @test id=POSIX_SPAWN
+ * @bug 8377907
+ * @summary Check that we don't open pipes without CLOEXCEC
+ * @requires os.family == "linux"
+ * @requires vm.flagless
+ * @library /test/lib
+ * @run main/othervm/native -Djdk.lang.Process.launchMechanism=POSIX_SPAWN PipesCloseOnExecTest
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+
+import java.io.IOException;
+import java.time.LocalTime;
+
+public class PipesCloseOnExecTest {
+
+    // How this works:
+    // - We start a child process A. Does not matter what, we just call "/bin/date".
+    // - Concurrently, we (natively, continuously) iterate all pipe file descriptors in
+    //   the process and count all those that are not tagged with CLOEXEC. Finding one
+    //   counts as error.
+
+    // Note that this test can only reliably succeed with Linux and the xxxBSDs, where
+    // we have pipe2(2).
+    //
+    // On MacOs and AIX, we emulate pipe2(2) with pipe(2) and fcntl(2); therefore we
+    // have a tiny time window in which a concurrent thread can can observe pipe
+    // filedescriptors without CLOEXEC. Furthermore, on MacOS, we also have to employ
+    // the double-dup-trick to workaround a the buggy MacOS implementation of posix_spawn.
+    // Therefore, on these platforms, the test would (correctly) spot "bad" file descriptors.
+
+    native static boolean startTester();
+    native static boolean stopTester();
+
+    static final int num_tries = 100;
+
+    static void printOpenFileDescriptors() {
+        long mypid =  ProcessHandle.current().pid();
+        try(Process p = new ProcessBuilder("lsof", "-p", Long.toString(mypid))
+                .inheritIO().start()) {
+            p.waitFor();
+        } catch (InterruptedException | IOException ignored) {
+            // Quietly swallow; it was just an attempt.
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        System.out.println("jdk.lang.Process.launchMechanism=" +
+                           System.getProperty("jdk.lang.Process.launchMechanism"));
+
+        System.loadLibrary("PipesCloseOnExec");
+
+        if (!startTester()) {
+            throw new RuntimeException("Failed to start testers (see stdout)");
+        }
+
+        System.out.println(LocalTime.now() + ": Call ProcessBuilder.start...");
+
+        for (int i = 0; i < num_tries; i ++) {
+            ProcessBuilder pb = new ProcessBuilder("true").inheritIO();
+            new OutputAnalyzer(pb.start()).shouldHaveExitValue(0);
+        }
+
+        if (!stopTester()) {
+            printOpenFileDescriptors();
+            throw new RuntimeException("Catched FDs without CLOEXEC? Check output.");
+        }
+    }
+}

--- a/test/jdk/java/lang/ProcessBuilder/PipesCloseOnExecTest/libPipesCloseOnExec.c
+++ b/test/jdk/java/lang/ProcessBuilder/PipesCloseOnExecTest/libPipesCloseOnExec.c
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, IBM Corp.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdatomic.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <jni.h>
+#include "testlib_thread_barriers.h"
+
+static void trc(const char* fmt, ...) {
+    char buf [1024];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+    printf("%s\n", buf);
+    fflush(stdout);
+}
+
+/* Set 1 to restrict this test to pipes, 0 to test all file descriptors.
+ * (for now, we ignore regular files opened with CLOEXEC since loaded jars seem not tagged as CLOEXEc.
+ * We should probably fix that eventually. */
+#define TEST_PIPES_ONLY 1
+
+/* stdin/out/err file descriptors are usually not CLOEXEC */
+#define IGNORE_BELOW 4
+
+/* Only query file descriptors up to this point */
+#define MAX_FD 1024
+
+static pthread_t tid_tester;
+
+static pthread_barrier_t start_barrier;
+static atomic_bool stop_now = false;
+
+/* Mainly to prevent tracing the same fd over and over again:
+ *   1 - present, 2 - present, cloexec */
+static unsigned fd_state[MAX_FD];
+
+static bool is_pipe(int fd) {
+    struct stat mystat;
+    if (fstat(fd, &mystat) == -1) {
+        return false;
+    }
+    return mystat.st_mode & S_IFIFO;
+}
+
+static void print_fd_details(int fd, char* out, size_t outlen) {
+    const char* type = "unknown";
+    char link[1024] = { 0 };
+    char procfd[129];
+    struct stat mystat;
+
+    out[0] = '\0';
+
+    if (fstat(fd, &mystat) == -1) {
+        snprintf(out, outlen, "%s", errno == EBADF ? "EBADF" : "???");
+        return;
+    }
+
+    switch (mystat.st_mode & S_IFMT) {
+        case S_IFBLK:  type = "blk"; break;
+        case S_IFCHR:  type = "char"; break;
+        case S_IFDIR:  type = "dir"; break;
+        case S_IFIFO:  type = "fifo"; break;
+        case S_IFLNK:  type = "lnk"; break;
+        case S_IFREG:  type = "reg"; break;
+        case S_IFSOCK: type = "sock"; break;
+    }
+
+    snprintf(procfd, sizeof(procfd) - 1, "/proc/self/fd/%d", fd);
+    int linklen = readlink(procfd, link, sizeof(link) - 1);
+    if (linklen > 0) {
+        link[linklen] = '\0';
+        snprintf(out, outlen, "%s (%s)", type, link);
+    } else {
+        snprintf(out, outlen, "%s", type);
+    }
+}
+
+/* Returns true for error */
+static bool testFD(int fd) {
+
+    int rc = fcntl(fd, F_GETFD);
+    if (rc == -1) {
+        return false;
+    }
+
+    const bool has_cloexec = (rc & FD_CLOEXEC);
+    const bool is_a_pipe = is_pipe(fd);
+    const unsigned state = has_cloexec ? 2 : 1;
+    bool had_error = false;
+
+    if (fd_state[fd] != state) {
+        fd_state[fd] = state;
+        char buf[1024];
+        print_fd_details(fd, buf, sizeof(buf));
+        if (has_cloexec) {
+            trc("%d: %s", fd, buf);
+        } else {
+            if (fd < IGNORE_BELOW) {
+                trc("%d: %s ** CLOEXEC MISSING ** (ignored - below scanned range)", fd, buf);
+            } else if (TEST_PIPES_ONLY && !is_a_pipe) {
+                trc("%d: %s ** CLOEXEC MISSING ** (ignored - not a pipe)", fd, buf);
+            } else {
+                trc("%d: %s ** CLOEXEC MISSING ** (ERROR)", fd, buf);
+                had_error = true;
+            }
+        }
+    }
+
+    return had_error;
+}
+
+static void* testerLoop(void* dummy) {
+
+    pthread_barrier_wait(&start_barrier);
+
+    trc("Tester is alive");
+
+    bool had_error = false;
+
+    while (!atomic_load(&stop_now)) {
+        for (int fd = 0; fd < MAX_FD; fd++) {
+            bool rc = testFD(fd);
+            had_error = had_error || rc;
+        }
+    }
+
+    trc("Tester dies");
+
+    return had_error ? (void*)1 : NULL;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_PipesCloseOnExecTest_startTester(JNIEnv* env, jclass cls)
+{
+    pthread_attr_t attr;
+    int rc = 0;
+
+    if (pthread_barrier_init(&start_barrier, NULL, 2) != 0) {
+        trc("pthread_barrier_init failed (%d)", errno);
+        return false;
+    }
+
+    pthread_attr_init(&attr);
+    if (pthread_create(&tid_tester, &attr, testerLoop, NULL) != 0) {
+        trc("pthread_create failed (%d)", errno);
+        return JNI_FALSE;
+    }
+
+    pthread_barrier_wait(&start_barrier);
+
+    trc("Started tester");
+
+    return JNI_TRUE;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_PipesCloseOnExecTest_stopTester(JNIEnv* env, jclass cls)
+{
+    atomic_store(&stop_now, true);
+
+    void* retval = NULL;
+    pthread_join(tid_tester, &retval);
+    pthread_barrier_destroy(&start_barrier);
+
+    return retval == NULL ? JNI_TRUE : JNI_FALSE;
+}

--- a/test/lib/native/testlib_thread_barriers.h
+++ b/test/lib/native/testlib_thread_barriers.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, IBM Corp.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef TESTLIB_THREAD_BARRIERS_H
+#define TESTLIB_THREAD_BARRIERS_H
+
+/* MacOS does not have pthread barriers; implement a fallback using condvars. */
+
+#ifndef _WIN32
+#if !defined _POSIX_BARRIERS || _POSIX_BARRIERS < 0
+
+#include <pthread.h>
+
+#define PTHREAD_BARRIER_SERIAL_THREAD       1
+
+#define pthread_barrier_t                       barr_t
+#define pthread_barrier_init(barr, attr, need)  barr_init(barr, attr, need)
+#define pthread_barrier_destroy(barr)           barr_destroy(barr)
+#define pthread_barrier_wait(barr)              barr_wait(barr)
+
+typedef struct {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    int have, need, trigger_count;
+} barr_t;
+
+int barr_init(barr_t* b, void* ignored, int need) {
+    b->have = b->trigger_count = 0;
+    b->need = need;
+    pthread_mutex_init(&b->mutex, NULL);
+    pthread_cond_init(&b->cond, NULL);
+    return 0;
+}
+
+int barr_destroy(barr_t* b) {
+    pthread_mutex_destroy(&b->mutex);
+    pthread_cond_destroy(&b->cond);
+    return 0;
+}
+
+int barr_wait(barr_t* b) {
+    pthread_mutex_lock(&b->mutex);
+    int my_trigger_count = b->trigger_count;
+    b->have++;
+    if (b->have == b->need) {
+        b->have = 0;
+        b->trigger_count++;
+        pthread_cond_broadcast(&b->cond);
+        pthread_mutex_unlock(&b->mutex);
+        return PTHREAD_BARRIER_SERIAL_THREAD;
+    }
+    while (my_trigger_count == b->trigger_count) { // no spurious wakeups
+        pthread_cond_wait(&b->cond, &b->mutex);
+    }
+    pthread_mutex_unlock(&b->mutex);
+    return 0;
+}
+
+#endif // !_POSIX_BARRIERS
+#endif // !_WIN32
+
+#endif // TESTLIB_THREAD_BARRIERS_H


### PR DESCRIPTION
A non-clean backport of a nasty bug in the subprocess layer that can lead to the parent process JVM locking up.

The patch is not clean since JDK 26 misses JDK-8291986. There is a single functional change from the patch necessary for JDK 26 since we miss JDK-8291986 - see my remark on the non-clean hunk. There were a few more conflicts, but those were trivial (e.g. copyright year).

Tested: jdk tier 1 and 2 on Linux x64. Ran all tests in ProcessBuilder, including those tests we wrote to trigger the bug this patch fixes, including the manual tests (ConcNativeForkTest) on Linux x64 and MacOS. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8377907](https://bugs.openjdk.org/browse/JDK-8377907) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8377907](https://bugs.openjdk.org/browse/JDK-8377907): (process) Race in ProcessBuilder can cause JVM hangs (**Bug** - P3 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/192/head:pull/192` \
`$ git checkout pull/192`

Update a local copy of the PR: \
`$ git checkout pull/192` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 192`

View PR using the GUI difftool: \
`$ git pr show -t 192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/192.diff">https://git.openjdk.org/jdk26u/pull/192.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/192#issuecomment-4418026549)
</details>
