### PR TITLE
8382090: Remove .rej and .orig from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,6 @@ NashornProfile.txt
 /.gdbinit
 /.lldbinit
 **/core.[0-9]*
-*.rej
-*.orig
 test/benchmarks/**/target
 /src/hotspot/CMakeLists.txt
 /src/hotspot/compile_commands.json


### PR DESCRIPTION
Clean backport.

Keeping .rej and .orig files visible to the developer is important. It helps minimizing human error when moving or applying source code changes.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8382090](https://bugs.openjdk.org/browse/JDK-8382090) needs maintainer approval

### Issue
 * [JDK-8382090](https://bugs.openjdk.org/browse/JDK-8382090): Remove .rej and .orig from .gitignore (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/193/head:pull/193` \
`$ git checkout pull/193`

Update a local copy of the PR: \
`$ git checkout pull/193` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 193`

View PR using the GUI difftool: \
`$ git pr show -t 193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/193.diff">https://git.openjdk.org/jdk26u/pull/193.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/193#issuecomment-4420170620)
</details>
