### PR TITLE
8376885: StressGetTotalGcCpuTimeDuringShutdown.java intermittently timed out

### DIFF
--- a/test/jdk/java/lang/management/MemoryMXBean/StressGetTotalGcCpuTimeDuringShutdown.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/StressGetTotalGcCpuTimeDuringShutdown.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,6 +79,8 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.ThreadMXBean;
 
+import jtreg.SkippedException;
+
 public class StressGetTotalGcCpuTimeDuringShutdown {
     static final ThreadMXBean mxThreadBean = ManagementFactory.getThreadMXBean();
     static final MemoryMXBean mxMemoryBean = ManagementFactory.getMemoryMXBean();
@@ -86,7 +88,7 @@ public class StressGetTotalGcCpuTimeDuringShutdown {
     public static void main(String[] args) throws Exception {
         try {
             if (!mxThreadBean.isThreadCpuTimeEnabled()) {
-                return;
+                throw new SkippedException("Thread CPU time is not enabled");
             }
         } catch (UnsupportedOperationException e) {
             if (mxMemoryBean.getTotalGcCpuTime() != -1) {
@@ -95,7 +97,8 @@ public class StressGetTotalGcCpuTimeDuringShutdown {
             return;
         }
 
-        final int numberOfThreads = Runtime.getRuntime().availableProcessors() * 8;
+        final int cpuCount = Runtime.getRuntime().availableProcessors() * 8;
+        final int numberOfThreads = Math.min(cpuCount, 128);
         for (int i = 0; i < numberOfThreads; i++) {
             Thread t = new Thread(() -> {
                 while (true) {
@@ -103,6 +106,7 @@ public class StressGetTotalGcCpuTimeDuringShutdown {
                     if (gcCpuTimeFromThread < -1) {
                         throw new RuntimeException("GC CPU time should never be less than -1 but was " + gcCpuTimeFromThread);
                     }
+                    Thread.onSpinWait();
                 }
             });
             t.setDaemon(true);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [cbda5317](https://github.com/openjdk/jdk/commit/cbda5317d69637416a490200452d561cc6fcffc2) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 13 May 2026 and was reviewed by Chris Plummer, Leonid Mesnik and Kevin Walls.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8376885](https://bugs.openjdk.org/browse/JDK-8376885) needs maintainer approval

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8376885](https://bugs.openjdk.org/browse/JDK-8376885): StressGetTotalGcCpuTimeDuringShutdown.java intermittently timed out (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/196/head:pull/196` \
`$ git checkout pull/196`

Update a local copy of the PR: \
`$ git checkout pull/196` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 196`

View PR using the GUI difftool: \
`$ git pr show -t 196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/196.diff">https://git.openjdk.org/jdk26u/pull/196.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/196#issuecomment-4438159335)
</details>
