### PR TITLE
(Withdrawn) 8383550: AsyncExceptionHandshakeClosure::do_thread() should not be passed nullptr

### DIFF
--- a/src/hotspot/share/runtime/javaThread.inline.hpp
+++ b/src/hotspot/share/runtime/javaThread.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -91,10 +91,14 @@ class AsyncExceptionHandshakeClosure : public AsyncHandshakeClosure {
   }
 
   void do_thread(Thread* thr) {
+    PRAGMA_DIAG_PUSH
+    PRAGMA_NONNULL_IGNORED
+    // Suppress GCC warning for nonnull as it doesn't recognize that `thr` is always the current thread.
     JavaThread* self = JavaThread::cast(thr);
     assert(self == JavaThread::current(), "must be");
 
     self->handle_async_exception(exception());
+    PRAGMA_DIAG_POP
   }
   oop exception() {
     assert(!_exception.is_empty(), "invariant");


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [7ecd0eae](https://github.com/openjdk/jdk/commit/7ecd0eae8629b08f3af24927c11fd0429f70a3ee) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Yasumasa Suenaga on 30 Apr 2026 and was reviewed by David Holmes and Patricio Chilano Mateo.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8383550](https://bugs.openjdk.org/browse/JDK-8383550) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8383550](https://bugs.openjdk.org/browse/JDK-8383550): AsyncExceptionHandshakeClosure::do_thread() should not be passed nullptr (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/198/head:pull/198` \
`$ git checkout pull/198`

Update a local copy of the PR: \
`$ git checkout pull/198` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 198`

View PR using the GUI difftool: \
`$ git pr show -t 198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/198.diff">https://git.openjdk.org/jdk26u/pull/198.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/198#issuecomment-4475857305)
</details>
