### PR TITLE
(Withdrawn) 8374168: Resolve disabled warnings in JDWP agent

### DIFF
--- a/make/modules/jdk.jdwp.agent/Lib.gmk
+++ b/make/modules/jdk.jdwp.agent/Lib.gmk
@@ -54,21 +54,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJDWP, \
     NAME := jdwp, \
     OPTIMIZATION := LOW, \
     CFLAGS := -DJDWP_LOGGING $(ICONV_CFLAGS), \
-    DISABLED_WARNINGS_gcc_eventFilter.c := unused-variable, \
-    DISABLED_WARNINGS_gcc_SDE.c := unused-function, \
-    DISABLED_WARNINGS_gcc_threadControl.c := unused-but-set-variable \
-        unused-variable, \
-    DISABLED_WARNINGS_gcc_utf_util.c := unused-but-set-variable, \
-    DISABLED_WARNINGS_clang_error_messages.c := format-nonliteral, \
-    DISABLED_WARNINGS_clang_eventFilter.c := unused-variable, \
-    DISABLED_WARNINGS_clang_EventRequestImpl.c := self-assign, \
-    DISABLED_WARNINGS_clang_inStream.c := sometimes-uninitialized, \
-    DISABLED_WARNINGS_clang_log_messages.c := format-nonliteral, \
-    DISABLED_WARNINGS_clang_SDE.c := unused-function, \
-    DISABLED_WARNINGS_clang_threadControl.c := unused-but-set-variable \
-        unused-variable, \
-    DISABLED_WARNINGS_clang_utf_util.c := unused-but-set-variable, \
-    DISABLED_WARNINGS_microsoft_debugInit.c := 5287, \
     LDFLAGS := $(ICONV_LDFLAGS), \
     EXTRA_HEADER_DIRS := \
         include \

--- a/src/jdk.jdwp.agent/share/native/libjdwp/EventRequestImpl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/EventRequestImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,12 +84,10 @@ readAndSetFilters(JNIEnv *env, PacketInputStream *in, HandlerNode *node,
             }
 
             case JDWP_REQUEST_MODIFIER(LocationOnly): {
-                jbyte tag;
                 jclass clazz;
                 jmethodID method;
                 jlocation location;
-                tag = inStream_readByte(in); /* not currently used */
-                tag = tag; /* To shut up lint */
+                (void)inStream_readByte(in); /* not currently used */
                 if ( (serror = inStream_error(in)) != JDWP_ERROR(NONE) )
                     break;
                 clazz = inStream_readClassRef(env, in);

--- a/src/jdk.jdwp.agent/share/native/libjdwp/SDE.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/SDE.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -716,19 +716,6 @@ private jboolean isValid(void);
         return lineTable[lti].njplsStart +
                 (((jplsLine - lineTable[lti].jplsStart) /
                                    lineTable[lti].jplsLineInc));
-    }
-
-    private int fileTableIndex(int sti, int fileId) {
-        int i;
-        int fileIndexStart = stratumTable[sti].fileIndex;
-        /* one past end */
-        int fileIndexEnd = stratumTable[sti+1].fileIndex;
-        for (i = fileIndexStart; i < fileIndexEnd; ++i) {
-            if (fileTable[i].fileId == fileId) {
-                return i;
-            }
-        }
-        return -1;
     }
 
     private jboolean isValid(void) {

--- a/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c
@@ -181,11 +181,11 @@ DEF_Agent_OnLoad(JavaVM *vm, char *options, void *reserved)
     vmInitialized = JNI_FALSE;
     gdata->vmDead = JNI_FALSE;
 
-    jvmtiCompileTimeMajorVersion  = ( JVMTI_VERSION & JVMTI_VERSION_MASK_MAJOR )
+    jvmtiCompileTimeMajorVersion  = ((unsigned)JVMTI_VERSION & JVMTI_VERSION_MASK_MAJOR)
                                         >> JVMTI_VERSION_SHIFT_MAJOR;
-    jvmtiCompileTimeMinorVersion  = ( JVMTI_VERSION & JVMTI_VERSION_MASK_MINOR )
+    jvmtiCompileTimeMinorVersion  = ((unsigned)JVMTI_VERSION & JVMTI_VERSION_MASK_MINOR)
                                         >> JVMTI_VERSION_SHIFT_MINOR;
-    jvmtiCompileTimeMicroVersion  = ( JVMTI_VERSION & JVMTI_VERSION_MASK_MICRO )
+    jvmtiCompileTimeMicroVersion  = ((unsigned)JVMTI_VERSION & JVMTI_VERSION_MASK_MICRO)
                                         >> JVMTI_VERSION_SHIFT_MICRO;
 
     /* Get the JVMTI Env, IMPORTANT: Do this first! For jvmtiAllocate(). */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/error_messages.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/error_messages.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,6 +61,8 @@
  *    NOTE: This function is at the lowest level of the call tree.
  *          Do not use the ERROR* macros here.
  */
+
+ATTRIBUTE_PRINTF(4, 0)
 static void
 vprint_message(FILE *fp, const char *prefix, const char *suffix,
                const char *format, va_list ap)
@@ -84,6 +86,7 @@ vprint_message(FILE *fp, const char *prefix, const char *suffix,
  *    NOTE: This function is at the lowest level of the call tree.
  *          Do not use the ERROR* macros here.
  */
+ATTRIBUTE_PRINTF(4, 5)
 void
 print_message(FILE *fp, const char *prefix,  const char *suffix,
               const char *format, ...)
@@ -96,6 +99,7 @@ print_message(FILE *fp, const char *prefix,  const char *suffix,
 }
 
 /* Generate error message */
+ATTRIBUTE_PRINTF(1, 2)
 void
 error_message(const char *format, ...)
 {
@@ -110,6 +114,7 @@ error_message(const char *format, ...)
 }
 
 /* Print plain message to stdout. */
+ATTRIBUTE_PRINTF(1, 2)
 void
 tty_message(const char *format, ...)
 {

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -976,7 +976,6 @@ eventFilter_setSourceNameMatchFilter(HandlerNode *node,
 
 jvmtiError eventFilter_setPlatformThreadsOnlyFilter(HandlerNode *node, jint index)
 {
-    PlatformThreadsFilter *filter = &FILTER(node, index).u.PlatformThreadsOnly;
     if (index >= FILTER_COUNT(node)) {
         return AGENT_ERROR_ILLEGAL_ARGUMENT;
     }

--- a/src/jdk.jdwp.agent/share/native/libjdwp/inStream.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/inStream.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -470,6 +470,7 @@ inStream_readValue(PacketInputStream *stream)
                 break;
             default:
                 stream->error = JDWP_ERROR(INVALID_TAG);
+                value.j = 0L; // to make compiler happy
                 break;
         }
     }

--- a/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -155,6 +155,7 @@ standard_logging_format(FILE *fp,
 }
 
 /* End a log entry */
+ATTRIBUTE_PRINTF(1, 2)
 void
 log_message_end(const char *format, ...)
 {

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -2663,12 +2663,16 @@ threadControl_setEventMode(jvmtiEventMode mode, EventIndex ei, jthread thread)
 
 /*
  * Returns the current thread.
+ * Returns NULL on error (JVMTI_ERROR_WRONG_PHASE, JVMTI_ERROR_UNATTACHED_THREAD).
  */
 jthread
 threadControl_currentThread(void)
 {
     jthread thread = NULL;
     jvmtiError error = JVMTI_FUNC_PTR(gdata->jvmti,GetCurrentThread)(gdata->jvmti, &thread);
+    if (error != JVMTI_ERROR_NONE) {
+        return NULL;
+    }
     return thread;
 }
 
@@ -2696,11 +2700,9 @@ threadControl_getFrameGeneration(jthread thread)
 jthread *
 threadControl_allVThreads(jint *numVThreads)
 {
-    JNIEnv *env;
     ThreadNode *node;
     jthread* vthreads;
 
-    env = getEnv();
     debugMonitorEnter(threadLock);
     *numVThreads = numRunningVThreads;
 

--- a/src/jdk.jdwp.agent/share/native/libjdwp/utf_util.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/utf_util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -173,7 +173,7 @@ int JNICALL utf8mToUtf8sLength(jbyte *string, int length) {
 
     newLength = 0;
     for ( i = 0 ; i < length ; i++ ) {
-        unsigned byte1, byte2, byte3, byte4, byte5, byte6;
+        unsigned byte1, byte2, byte4, byte5, byte6;
 
         byte1 = (unsigned char)string[i];
         if ( (byte1 & 0x80) == 0 ) { /* 1byte encoding */
@@ -196,7 +196,7 @@ int JNICALL utf8mToUtf8sLength(jbyte *string, int length) {
                 break; /* Error condition */
             }
             byte2 = (unsigned char)string[++i];
-            byte3 = (unsigned char)string[++i];
+            ++i; // byte3 is not used
             newLength += 3;
             /* Possible process a second 3byte encoding */
             if ( (i+3) < length && byte1 == 0xED && (byte2 & 0xF0) == 0xA0 ) {

--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.h
@@ -59,6 +59,14 @@
 #include "error_messages.h"
 #include "debugInit.h"
 
+/* To handle "format string is not a string literal" warning. */
+#if !defined(_MSC_VER)
+  #define ATTRIBUTE_PRINTF(fmt_pos_num, vargs_pos_num) \
+          __attribute__((format(printf, fmt_pos_num, vargs_pos_num)))
+#else
+  #define ATTRIBUTE_PRINTF(fmt_pos_num, vargs_pos_num)
+#endif
+
 /* Definition of a CommonRef tracked by the backend for the frontend */
 typedef struct RefNode {
     jlong        seqNum;        /* ID of reference, also key for hash table */


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [fa8ea6b3](https://github.com/openjdk/jdk/commit/fa8ea6b32d463a84affa529d37cfb97280503fc6) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Alex Menkov on 5 Jan 2026 and was reviewed by Chris Plummer, Serguei Spitsyn and Erik Joelsson.

Thanks!

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8374168](https://bugs.openjdk.org/browse/JDK-8374168) needs maintainer approval

### Issue
 * [JDK-8374168](https://bugs.openjdk.org/browse/JDK-8374168): Resolve disabled warnings in JDWP agent (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/199/head:pull/199` \
`$ git checkout pull/199`

Update a local copy of the PR: \
`$ git checkout pull/199` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 199`

View PR using the GUI difftool: \
`$ git pr show -t 199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/199.diff">https://git.openjdk.org/jdk26u/pull/199.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/199#issuecomment-4489782893)
</details>
