### PR TITLE
8385011: GHA: Enable Linux AArch64 tests

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -54,18 +54,11 @@ jobs:
       fail-fast: false
       matrix:
         target-cpu:
-          - aarch64
           - arm
           - s390x
           - ppc64le
           - riscv64
         include:
-          - target-cpu: aarch64
-            gnu-arch: aarch64
-            debian-arch: arm64
-            debian-repository: https://httpredir.debian.org/debian/
-            debian-version: trixie
-            tolerate-sysroot-errors: false
           - target-cpu: arm
             gnu-arch: arm
             debian-arch: armhf

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -31,6 +31,14 @@ on:
       platform:
         required: true
         type: string
+      runs-on:
+        required: false
+        type: string
+        default: 'ubuntu-24.04'
+      bootjdk-platform:
+        required: false
+        type: string
+        default: 'linux-x64'
       extra-conf-options:
         required: false
         type: string
@@ -75,7 +83,7 @@ on:
 jobs:
   build-linux:
     name: build
-    runs-on: ubuntu-24.04
+    runs-on: ${{ inputs.runs-on }}
 
     strategy:
       fail-fast: false
@@ -90,7 +98,7 @@ jobs:
         id: bootjdk
         uses: ./.github/actions/get-bootjdk
         with:
-          platform: linux-x64
+          platform: ${{ inputs.bootjdk-platform }}
 
       - name: 'Get JTReg'
         id: jtreg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ on:
       platforms:
         description: 'Platform(s) to execute on (comma separated, e.g. "linux-x64, macos, aarch64")'
         required: true
-        default: 'linux-x64, linux-x64-variants, linux-cross-compile, alpine-linux-x64, macos-x64, macos-aarch64, windows-x64, windows-aarch64, docs'
+        default: 'linux-x64, linux-x64-variants, linux-aarch64, linux-cross-compile, alpine-linux-x64, macos-x64, macos-aarch64, windows-x64, windows-aarch64, docs'
       configure-arguments:
         description: 'Additional configure arguments'
         required: false
@@ -64,6 +64,7 @@ jobs:
     outputs:
       linux-x64: ${{ steps.include.outputs.linux-x64 }}
       linux-x64-variants: ${{ steps.include.outputs.linux-x64-variants }}
+      linux-aarch64: ${{ steps.include.outputs.linux-aarch64 }}
       linux-cross-compile: ${{ steps.include.outputs.linux-cross-compile }}
       alpine-linux-x64: ${{ steps.include.outputs.alpine-linux-x64 }}
       macos-x64: ${{ steps.include.outputs.macos-x64 }}
@@ -176,6 +177,7 @@ jobs:
 
           echo "linux-x64=$(check_platform linux-x64 linux x64)" >> $GITHUB_OUTPUT
           echo "linux-x64-variants=$(check_platform linux-x64-variants variants)" >> $GITHUB_OUTPUT
+          echo "linux-aarch64=$(check_platform linux-aarch64 linux aarch64)" >> $GITHUB_OUTPUT
           echo "linux-cross-compile=$(check_platform linux-cross-compile cross-compile)" >> $GITHUB_OUTPUT
           echo "alpine-linux-x64=$(check_platform alpine-linux-x64 alpine-linux x64)" >> $GITHUB_OUTPUT
           echo "macos-x64=$(check_platform macos-x64 macos x64)" >> $GITHUB_OUTPUT
@@ -200,6 +202,20 @@ jobs:
       make-arguments: ${{ github.event.inputs.make-arguments }}
       dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
     if: needs.prepare.outputs.linux-x64 == 'true'
+
+  build-linux-aarch64:
+    name: linux-aarch64
+    needs: prepare
+    uses: ./.github/workflows/build-linux.yml
+    with:
+      platform: linux-aarch64
+      runs-on: 'ubuntu-24.04-arm'
+      bootjdk-platform: linux-aarch64
+      gcc-major-version: '14'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
+      dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
+    if: needs.prepare.outputs.linux-aarch64 == 'true'
 
   build-linux-x64-hs-nopch:
     name: linux-x64-hs-nopch
@@ -422,6 +438,19 @@ jobs:
       runs-on: ubuntu-24.04
       dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
       static-suffix: "-static"
+
+  test-linux-aarch64:
+    name: linux-aarch64
+    needs:
+      - prepare
+      - build-linux-aarch64
+    uses: ./.github/workflows/test.yml
+    with:
+      platform: linux-aarch64
+      bootjdk-platform: linux-aarch64
+      runs-on: ubuntu-24.04-arm
+      dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
+      debug-suffix: -debug
 
   test-macos-aarch64:
     name: macos-aarch64

--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -32,6 +32,10 @@ LINUX_X64_BOOT_JDK_EXT=tar.gz
 LINUX_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk25/bd75d5f9689641da8e1daabeccb5528b/36/GPL/openjdk-25_linux-x64_bin.tar.gz
 LINUX_X64_BOOT_JDK_SHA256=59cdcaf255add4721de38eb411d4ecfe779356b61fb671aee63c7dec78054c2b
 
+LINUX_AARCH64_BOOT_JDK_EXT=tar.gz
+LINUX_AARCH64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk25/bd75d5f9689641da8e1daabeccb5528b/36/GPL/openjdk-25_linux-aarch64_bin.tar.gz
+LINUX_AARCH64_BOOT_JDK_SHA256=f4a8d27429458a529148f90ebafcd1ae9b1968fa323f9e5e40d579a5c8c0288f
+
 ALPINE_LINUX_X64_BOOT_JDK_EXT=tar.gz
 ALPINE_LINUX_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B36/OpenJDK25U-jdk_x64_alpine-linux_hotspot_25_36.tar.gz
 ALPINE_LINUX_X64_BOOT_JDK_SHA256=637e47474d411ed86134f413af7d5fef4180ddb0bf556347b7e74a88cf8904c8


### PR DESCRIPTION
Backport of https://github.com/openjdk/jdk/commit/2e113542fc65ce16a3fe78296a661305533216de. Backport applies cleanly other than the BootJDK version differences in `make/conf/github-actions.conf`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8385011](https://bugs.openjdk.org/browse/JDK-8385011) needs maintainer approval
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #205 must be integrated first

### Issue
 * [JDK-8385011](https://bugs.openjdk.org/browse/JDK-8385011): GHA: Enable Linux AArch64 tests (**Enhancement** - P4 - Requested)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/203/head:pull/203` \
`$ git checkout pull/203`

Update a local copy of the PR: \
`$ git checkout pull/203` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 203`

View PR using the GUI difftool: \
`$ git pr show -t 203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/203.diff">https://git.openjdk.org/jdk26u/pull/203.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/203#issuecomment-4501184276)
</details>
