### PR TITLE
8371651: [AArch64] Populate CPU _features flag on Windows

### DIFF
--- a/src/hotspot/os_cpu/windows_aarch64/sve_windows_aarch64.S
+++ b/src/hotspot/os_cpu/windows_aarch64/sve_windows_aarch64.S
@@ -1,0 +1,42 @@
+;
+; Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+;
+; This code is free software; you can redistribute it and/or modify it
+; under the terms of the GNU General Public License version 2 only, as
+; published by the Free Software Foundation.
+;
+; This code is distributed in the hope that it will be useful, but WITHOUT
+; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+; version 2 for more details (a copy is included in the LICENSE file that
+; accompanied this code).
+;
+; You should have received a copy of the GNU General Public License version
+; 2 along with this work; if not, write to the Free Software Foundation,
+; Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+;
+; Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+; or visit www.oracle.com if you need additional information or have any
+; questions.
+;
+
+    ; Support for int get_sve_vector_length();
+    ;
+    ; Returns the current SVE vector length in bytes.
+    ; This function uses the INCB instruction which increments a register
+    ; by the number of bytes in an SVE vector register.
+    ;
+    ; Note: This function will fault if SVE is not available or enabled.
+    ; The caller must ensure SVE support is detected before calling.
+
+    ALIGN  4
+    EXPORT get_sve_vector_length
+    AREA sve_text, CODE
+
+get_sve_vector_length
+    mov      x0, #0
+    incb     x0
+    ret
+
+    END

--- a/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
@@ -26,16 +26,19 @@
 #include "runtime/os.hpp"
 #include "runtime/vm_version.hpp"
 
+// Assembly function to get SVE vector length using INCB instruction
+extern "C" int get_sve_vector_length();
+
 int VM_Version::get_current_sve_vector_length() {
   assert(VM_Version::supports_sve(), "should not call this");
-  ShouldNotReachHere();
-  return 0;
+  // Use assembly instruction to get the actual SVE vector length
+  return  VM_Version::supports_sve() ? get_sve_vector_length() : 0; // This value is in bytes
 }
 
 int VM_Version::set_and_get_current_sve_vector_length(int length) {
   assert(VM_Version::supports_sve(), "should not call this");
-  ShouldNotReachHere();
-  return 0;
+  // Use assembly instruction to get the SVE vector length
+  return VM_Version::supports_sve() ? get_sve_vector_length() : 0; // This value is in bytes
 }
 
 void VM_Version::get_os_cpu_info() {
@@ -47,11 +50,29 @@ void VM_Version::get_os_cpu_info() {
     set_feature(CPU_AES);
     set_feature(CPU_SHA1);
     set_feature(CPU_SHA2);
+    set_feature(CPU_PMULL);
   }
   if (IsProcessorFeaturePresent(PF_ARM_VFP_32_REGISTERS_AVAILABLE)) {
     set_feature(CPU_ASIMD);
   }
-  // No check for CPU_PMULL, CPU_SVE, CPU_SVE2
+  if (IsProcessorFeaturePresent(PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE)) {
+    set_feature(CPU_LSE);
+  }
+  if (IsProcessorFeaturePresent(PF_ARM_SVE_INSTRUCTIONS_AVAILABLE)) {
+    set_feature(CPU_SVE);
+  }
+  if (IsProcessorFeaturePresent(PF_ARM_SVE2_INSTRUCTIONS_AVAILABLE)) {
+    set_feature(CPU_SVE2);
+  }
+  if (IsProcessorFeaturePresent(PF_ARM_SVE_BITPERM_INSTRUCTIONS_AVAILABLE)) {
+    set_feature(CPU_SVEBITPERM);
+  }
+  if (IsProcessorFeaturePresent(PF_ARM_SHA3_INSTRUCTIONS_AVAILABLE)) {
+    set_feature(CPU_SHA3);
+  }
+  if (IsProcessorFeaturePresent(PF_ARM_SHA512_INSTRUCTIONS_AVAILABLE)) {
+    set_feature(CPU_SHA512);
+  }
 
   __int64 dczid_el0 = _ReadStatusReg(0x5807 /* ARM64_DCZID_EL0 */);
 
@@ -102,8 +123,8 @@ void VM_Version::get_os_cpu_info() {
       SYSTEM_INFO si;
       GetSystemInfo(&si);
       _model = si.wProcessorLevel;
-      _variant = si.wProcessorRevision / 0xFF;
-      _revision = si.wProcessorRevision & 0xFF;
+      _variant = (si.wProcessorRevision >> 8) & 0xFF; // Variant is the upper byte of wProcessorRevision
+      _revision = si.wProcessorRevision & 0xFF; // Revision is the lower byte of wProcessorRevision
     }
   }
 }


### PR DESCRIPTION
Backports 8371651: [AArch64] Populate CPU _features flag on Windows

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8371651](https://bugs.openjdk.org/browse/JDK-8371651) needs maintainer approval

### Issue
 * [JDK-8371651](https://bugs.openjdk.org/browse/JDK-8371651): [AArch64] Populate CPU _features flag on Windows (**Enhancement** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/204/head:pull/204` \
`$ git checkout pull/204`

Update a local copy of the PR: \
`$ git checkout pull/204` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 204`

View PR using the GUI difftool: \
`$ git pr show -t 204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/204.diff">https://git.openjdk.org/jdk26u/pull/204.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/204#issuecomment-4502848798)
</details>
