### PR TITLE
8381617: vm_version_windows_aarch64.cpp: PF_ARM_SVE_INSTRUCTIONS_AVAILABLE undeclared identifier

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -59,9 +59,9 @@ protected:
   // Read additional info using OS-specific interfaces
   static void get_os_cpu_info();
 
-  // Sets the SVE length and returns a new actual value or negative on error.
-  // If the len is larger than the system largest supported SVE vector length,
-  // the function sets the largest supported value.
+  // Set the SVE vector length to len. If the vector length cannot be
+  // changed to len, set the length to the largest possible value.
+  // Return the length that will be used, or -ve if an error occurred.
   static int set_and_get_current_sve_vector_length(int len);
   static int get_current_sve_vector_length();
 

--- a/src/hotspot/os_cpu/windows_aarch64/sve_windows_aarch64.S
+++ b/src/hotspot/os_cpu/windows_aarch64/sve_windows_aarch64.S
@@ -24,19 +24,26 @@
     ; Support for int get_sve_vector_length();
     ;
     ; Returns the current SVE vector length in bytes.
-    ; This function uses the INCB instruction which increments a register
-    ; by the number of bytes in an SVE vector register.
+    ; This function uses the RDVL instruction which reads a multiple of the
+    ; vector register size into a scalar register.
     ;
-    ; Note: This function will fault if SVE is not available or enabled.
-    ; The caller must ensure SVE support is detected before calling.
+    ; Note: This function will fault if SVE is not available or enabled.  The
+    ; caller must ensure SVE support is detected before calling.
 
     ALIGN  4
     EXPORT get_sve_vector_length
     AREA sve_text, CODE
 
 get_sve_vector_length
-    mov      x0, #0
-    incb     x0
+    ; Older versions of Visual Studio aren't aware of SVE mnemonics, so we use
+    ; the raw instruction encoding to satisfy the compiler.  This function call
+    ; is gated by `VM_Version::supports_sve()`, so this instruction will never
+    ; run on non-SVE hardware.
+    ;
+    ; See https://www.scs.stanford.edu/~zyedidia/arm64/rdvl_r_i.html for a quick
+    ; reference to the instruction encoding.
+
+    DCD      0x04BF5020   ; rdvl x0, #1 (i.e. x0 = 1 * vector_length_in_bytes)
     ret
 
     END

--- a/src/hotspot/os_cpu/windows_aarch64/sve_windows_aarch64.S
+++ b/src/hotspot/os_cpu/windows_aarch64/sve_windows_aarch64.S
@@ -1,0 +1,42 @@
+;
+; Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+;
+; This code is free software; you can redistribute it and/or modify it
+; under the terms of the GNU General Public License version 2 only, as
+; published by the Free Software Foundation.
+;
+; This code is distributed in the hope that it will be useful, but WITHOUT
+; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+; version 2 for more details (a copy is included in the LICENSE file that
+; accompanied this code).
+;
+; You should have received a copy of the GNU General Public License version
+; 2 along with this work; if not, write to the Free Software Foundation,
+; Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+;
+; Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+; or visit www.oracle.com if you need additional information or have any
+; questions.
+;
+
+    ; Support for int get_sve_vector_length();
+    ;
+    ; Returns the current SVE vector length in bytes.
+    ; This function uses the INCB instruction which increments a register
+    ; by the number of bytes in an SVE vector register.
+    ;
+    ; Note: This function will fault if SVE is not available or enabled.
+    ; The caller must ensure SVE support is detected before calling.
+
+    ALIGN  4
+    EXPORT get_sve_vector_length
+    AREA sve_text, CODE
+
+get_sve_vector_length
+    mov      x0, #0
+    incb     x0
+    ret
+
+    END

--- a/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
@@ -26,16 +26,19 @@
 #include "runtime/os.hpp"
 #include "runtime/vm_version.hpp"
 
+// Assembly function to get SVE vector length using INCB instruction
+extern "C" int get_sve_vector_length();
+
 int VM_Version::get_current_sve_vector_length() {
   assert(VM_Version::supports_sve(), "should not call this");
-  ShouldNotReachHere();
-  return 0;
+  // Use assembly instruction to get the actual SVE vector length
+  return  VM_Version::supports_sve() ? get_sve_vector_length() : 0; // This value is in bytes
 }
 
 int VM_Version::set_and_get_current_sve_vector_length(int length) {
   assert(VM_Version::supports_sve(), "should not call this");
-  ShouldNotReachHere();
-  return 0;
+  // Use assembly instruction to get the SVE vector length
+  return VM_Version::supports_sve() ? get_sve_vector_length() : 0; // This value is in bytes
 }
 
 void VM_Version::get_os_cpu_info() {
@@ -47,11 +50,29 @@ void VM_Version::get_os_cpu_info() {
     set_feature(CPU_AES);
     set_feature(CPU_SHA1);
     set_feature(CPU_SHA2);
+    set_feature(CPU_PMULL);
   }
   if (IsProcessorFeaturePresent(PF_ARM_VFP_32_REGISTERS_AVAILABLE)) {
     set_feature(CPU_ASIMD);
   }
-  // No check for CPU_PMULL, CPU_SVE, CPU_SVE2
+  if (IsProcessorFeaturePresent(PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE)) {
+    set_feature(CPU_LSE);
+  }
+  if (IsProcessorFeaturePresent(PF_ARM_SVE_INSTRUCTIONS_AVAILABLE)) {
+    set_feature(CPU_SVE);
+  }
+  if (IsProcessorFeaturePresent(PF_ARM_SVE2_INSTRUCTIONS_AVAILABLE)) {
+    set_feature(CPU_SVE2);
+  }
+  if (IsProcessorFeaturePresent(PF_ARM_SVE_BITPERM_INSTRUCTIONS_AVAILABLE)) {
+    set_feature(CPU_SVEBITPERM);
+  }
+  if (IsProcessorFeaturePresent(PF_ARM_SHA3_INSTRUCTIONS_AVAILABLE)) {
+    set_feature(CPU_SHA3);
+  }
+  if (IsProcessorFeaturePresent(PF_ARM_SHA512_INSTRUCTIONS_AVAILABLE)) {
+    set_feature(CPU_SHA512);
+  }
 
   __int64 dczid_el0 = _ReadStatusReg(0x5807 /* ARM64_DCZID_EL0 */);
 
@@ -102,8 +123,8 @@ void VM_Version::get_os_cpu_info() {
       SYSTEM_INFO si;
       GetSystemInfo(&si);
       _model = si.wProcessorLevel;
-      _variant = si.wProcessorRevision / 0xFF;
-      _revision = si.wProcessorRevision & 0xFF;
+      _variant = (si.wProcessorRevision >> 8) & 0xFF; // Variant is the upper byte of wProcessorRevision
+      _revision = si.wProcessorRevision & 0xFF; // Revision is the lower byte of wProcessorRevision
     }
   }
 }

--- a/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
@@ -26,19 +26,52 @@
 #include "runtime/os.hpp"
 #include "runtime/vm_version.hpp"
 
-// Assembly function to get SVE vector length using INCB instruction
+// Since PF_ARM_SVE_INSTRUCTIONS_AVAILABLE and related constants were added in
+// Windows 11 (version 24H2) and in Windows Server 2025, we define them here for
+// compatibility with older SDK versions.
+#ifndef PF_ARM_SVE_INSTRUCTIONS_AVAILABLE
+#define PF_ARM_SVE_INSTRUCTIONS_AVAILABLE 46
+#endif
+
+#ifndef PF_ARM_SVE2_INSTRUCTIONS_AVAILABLE
+#define PF_ARM_SVE2_INSTRUCTIONS_AVAILABLE 47
+#endif
+
+#ifndef PF_ARM_SVE_BITPERM_INSTRUCTIONS_AVAILABLE
+#define PF_ARM_SVE_BITPERM_INSTRUCTIONS_AVAILABLE 51
+#endif
+
+#ifndef PF_ARM_SHA3_INSTRUCTIONS_AVAILABLE
+#define PF_ARM_SHA3_INSTRUCTIONS_AVAILABLE 64
+#endif
+
+#ifndef PF_ARM_SHA512_INSTRUCTIONS_AVAILABLE
+#define PF_ARM_SHA512_INSTRUCTIONS_AVAILABLE 65
+#endif
+
+#ifndef PF_ARM_V82_FP16_INSTRUCTIONS_AVAILABLE
+#define PF_ARM_V82_FP16_INSTRUCTIONS_AVAILABLE 67
+#endif
+
+// Assembly function to get SVE vector length using RDVL instruction
 extern "C" int get_sve_vector_length();
 
 int VM_Version::get_current_sve_vector_length() {
   assert(VM_Version::supports_sve(), "should not call this");
-  // Use assembly instruction to get the actual SVE vector length
-  return  VM_Version::supports_sve() ? get_sve_vector_length() : 0; // This value is in bytes
+  return VM_Version::supports_sve() ? get_sve_vector_length() : 0;
 }
 
 int VM_Version::set_and_get_current_sve_vector_length(int length) {
   assert(VM_Version::supports_sve(), "should not call this");
-  // Use assembly instruction to get the SVE vector length
-  return VM_Version::supports_sve() ? get_sve_vector_length() : 0; // This value is in bytes
+
+  // Unlike Linux, Windows does not present a way to modify the VL (the
+  // rationale is that the OS expects the application to use the maximum vector
+  // length supported by the hardware), so we simply return the current VL.  If
+  // the user sets `MaxVectorSize` that is not the same as the maximum possible
+  // vector length, then the caller (`VM_Version::initialize()`) will print a
+  // warning, set `MaxVectorSize` to the value returned by this function, and
+  // move on.
+  return VM_Version::supports_sve() ? get_sve_vector_length() : 0;
 }
 
 void VM_Version::get_os_cpu_info() {
@@ -66,6 +99,10 @@ void VM_Version::get_os_cpu_info() {
   }
   if (IsProcessorFeaturePresent(PF_ARM_SVE_BITPERM_INSTRUCTIONS_AVAILABLE)) {
     set_feature(CPU_SVEBITPERM);
+  }
+  if (IsProcessorFeaturePresent(PF_ARM_V82_FP16_INSTRUCTIONS_AVAILABLE)) {
+    set_feature(CPU_FPHP);
+    set_feature(CPU_ASIMDHP);
   }
   if (IsProcessorFeaturePresent(PF_ARM_SHA3_INSTRUCTIONS_AVAILABLE)) {
     set_feature(CPU_SHA3);

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestFloat16ScalarOperations.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestFloat16ScalarOperations.java
@@ -24,7 +24,7 @@
 
 /**
 * @test
-* @bug 8308363 8336406
+* @bug 8308363 8336406 8381617
 * @summary Validate compiler IR for various Float16 scalar operations.
 * @modules jdk.incubator.vector
 * @requires vm.compiler2.enabled
@@ -714,9 +714,13 @@ public class TestFloat16ScalarOperations {
 
     @Test
     @IR(counts = {IRNode.FMA_HF, " 0 ", IRNode.REINTERPRET_S2HF, " 0 ", IRNode.REINTERPRET_HF2S, " 0 "},
-        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zfh", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zfh", "true"},
+        // On Windows, both GCC and MSVC don't set __STDC_IEC_559__, so FMAs on constants are not folded.
+        applyIfPlatform = {"windows", "false"})
     @IR(counts = {IRNode.FMA_HF, " 0 ", IRNode.REINTERPRET_S2HF, " 0 ", IRNode.REINTERPRET_HF2S, " 0 "},
-        applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
+        applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"},
+        // On Windows, both GCC and MSVC don't set __STDC_IEC_559__, so FMAs on constants are not folded.
+        applyIfPlatform = {"windows", "false"})
     @Warmup(10000)
     public void testFMAConstantFolding() {
         // If any argument is NaN, the result is NaN.
@@ -752,9 +756,13 @@ public class TestFloat16ScalarOperations {
 
     @Test
     @IR(failOn = {IRNode.ADD_HF, IRNode.SUB_HF, IRNode.MUL_HF, IRNode.DIV_HF, IRNode.SQRT_HF, IRNode.FMA_HF},
-        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zfh", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zfh", "true"},
+        // On Windows, both GCC and MSVC don't set __STDC_IEC_559__, so FMAs on constants are not folded.
+        applyIfPlatform = {"windows", "false"})
     @IR(failOn = {IRNode.ADD_HF, IRNode.SUB_HF, IRNode.MUL_HF, IRNode.DIV_HF, IRNode.SQRT_HF, IRNode.FMA_HF},
-        applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
+        applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"},
+        // On Windows, both GCC and MSVC don't set __STDC_IEC_559__, so FMAs on constants are not folded.
+        applyIfPlatform = {"windows", "false"})
     @Warmup(10000)
     public void testRounding1() {
         dst[0] = float16ToRawShortBits(add(RANDOM1, RANDOM2));

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestReductions.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestReductions.java
@@ -1588,7 +1588,7 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_L,    "> 0",
                   IRNode.MUL_REDUCTION_VL, "> 0",
                   IRNode.MUL_VL,           "> 0"}, // vector accumulator
-        applyIfCPUFeature = {"avx512dq", "true"},
+        applyIfCPUFeatureOr = {"avx512dq", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_L,
         applyIfCPUFeatureAnd = {"avx512dq", "false", "sse4.1", "true"})
@@ -1596,7 +1596,7 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_L,    "> 0",
                   IRNode.MUL_REDUCTION_VL, "> 0",
                   IRNode.MUL_VL,           "= 0"}, // Reduction NOT moved out of loop
-        applyIfCPUFeatureOr = {"asimd", "true"},
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     // Note: NEON does not support MulVL for auto vectorization. There is
     //       a scalarized implementation, but that is not profitable for
@@ -1660,10 +1660,10 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_L,   "> 0",
                   IRNode.AND_REDUCTION_V, "> 0",
                   IRNode.AND_VL,          "> 0"},
-        applyIfCPUFeature = {"sse4.1", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_L,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // While AndReductionV is implemented in NEON (see longAndSimple), MulVL is not.
     // Filed: JDK-8370686
     @IR(failOn = IRNode.LOAD_VECTOR_L,
@@ -1681,10 +1681,10 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_L,  "> 0",
                   IRNode.OR_REDUCTION_V, "> 0",
                   IRNode.OR_VL,          "> 0"},
-        applyIfCPUFeature = {"sse4.1", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_L,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // While OrReductionV is implemented in NEON (see longOrSimple), MulVL is not.
     // Filed: JDK-8370686
     @IR(failOn = IRNode.LOAD_VECTOR_L,
@@ -1702,10 +1702,10 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_L,   "> 0",
                   IRNode.XOR_REDUCTION_V, "> 0",
                   IRNode.XOR_VL,          "> 0"},
-        applyIfCPUFeature = {"sse4.1", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_L,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // While MaxReductionV is implemented in NEON (see longXorSimple), MulVL is not.
     // Filed: JDK-8370686
     @IR(failOn = IRNode.LOAD_VECTOR_L,
@@ -1723,10 +1723,10 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_L,    "> 0",
                   IRNode.ADD_REDUCTION_VL, "> 0",
                   IRNode.ADD_VL,           "> 0"},
-        applyIfCPUFeature = {"sse4.1", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_L,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // While MaxReductionV is implemented in NEON (see longAddSimple), MulVL is not.
     // Filed: JDK-8370686
     @IR(failOn = IRNode.LOAD_VECTOR_L,
@@ -1744,13 +1744,13 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_L,    "> 0",
                   IRNode.MUL_REDUCTION_VL, "> 0",
                   IRNode.MUL_VL,           "> 0"},
-        applyIfCPUFeature = {"avx512dq", "true"},
+        applyIfCPUFeatureOr = {"avx512dq", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_L,
         applyIfCPUFeatureAnd = {"avx512dq", "false", "sse4.1", "true"})
     // I think this could vectorize, but currently does not. Filed: JDK-8370673
     @IR(failOn = IRNode.LOAD_VECTOR_L,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // MulVL is not implemented on NEON, so we also not have the reduction.
     // Filed: JDK-8370686
     @IR(failOn = IRNode.LOAD_VECTOR_L,
@@ -1768,13 +1768,13 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_L,   "> 0",
                   IRNode.MIN_REDUCTION_V, "> 0",
                   IRNode.MIN_VL,          "> 0"},
-        applyIfCPUFeature = {"avx512", "true"},
+        applyIfCPUFeatureOr = {"avx512", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_L,
         applyIfCPUFeatureAnd = {"avx512", "false", "avx2", "true"})
     // I think this could vectorize, but currently does not. Filed: JDK-8370671
     @IR(failOn = IRNode.LOAD_VECTOR_L,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // While MaxReductionV is implemented in NEON (see longMinSimple), MulVL is not.
     // Filed: JDK-8370686
     @IR(failOn = IRNode.LOAD_VECTOR_L,
@@ -1792,13 +1792,13 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_L,   "> 0",
                   IRNode.MAX_REDUCTION_V, "> 0",
                   IRNode.MAX_VL,          "> 0"},
-        applyIfCPUFeature = {"avx512", "true"},
+        applyIfCPUFeatureOr = {"avx512", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_L,
         applyIfCPUFeatureAnd = {"avx512", "false", "avx2", "true"})
     // I think this could vectorize, but currently does not. Filed: JDK-8370671
     @IR(failOn = IRNode.LOAD_VECTOR_L,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // While MaxReductionV is implemented in NEON (see longMaxSimple), MulVL is not.
     // Filed: JDK-8370686
     @IR(failOn = IRNode.LOAD_VECTOR_L,
@@ -1817,10 +1817,10 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_L,   "> 0",
                   IRNode.AND_REDUCTION_V, "> 0",
                   IRNode.AND_VL,          "> 0"},
-        applyIfCPUFeature = {"sse4.1", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_L,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // While AndReductionV is implemented in NEON (see longAndSimple), MulVL is not.
     // Filed: JDK-8370686
     @IR(failOn = IRNode.LOAD_VECTOR_L,
@@ -1838,10 +1838,10 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_L,  "> 0",
                   IRNode.OR_REDUCTION_V, "> 0",
                   IRNode.OR_VL,          "> 0"},
-        applyIfCPUFeature = {"sse4.1", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_L,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // While OrReductionV is implemented in NEON (see longOrSimple), MulVL is not.
     // Filed: JDK-8370686
     @IR(failOn = IRNode.LOAD_VECTOR_L,
@@ -1859,10 +1859,10 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_L,   "> 0",
                   IRNode.XOR_REDUCTION_V, "> 0",
                   IRNode.XOR_VL,          "> 0"},
-        applyIfCPUFeature = {"sse4.1", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_L,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // While MaxReductionV is implemented in NEON (see longXorSimple), MulVL is not.
     // Filed: JDK-8370686
     @IR(failOn = IRNode.LOAD_VECTOR_L,
@@ -1880,10 +1880,10 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_L,    "> 0",
                   IRNode.ADD_REDUCTION_VL, "> 0",
                   IRNode.ADD_VL,           "> 0"},
-        applyIfCPUFeature = {"sse4.1", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_L,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // While MaxReductionV is implemented in NEON (see longAddSimple), MulVL is not.
     // Filed: JDK-8370686
     @IR(failOn = IRNode.LOAD_VECTOR_L,
@@ -1901,7 +1901,7 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_L,    "> 0",
                   IRNode.MUL_REDUCTION_VL, "> 0",
                   IRNode.MUL_VL,           "> 0"},
-        applyIfCPUFeature = {"avx512dq", "true"},
+        applyIfCPUFeatureOr = {"avx512dq", "true", "sve", "true"},
         applyIfAnd = {"AutoVectorizationOverrideProfitability", "> 0",
                       "LoopUnrollLimit", ">= 1000"})
     @IR(failOn = IRNode.LOAD_VECTOR_L,
@@ -1912,7 +1912,7 @@ public class TestReductions {
     // If you can eliminate this exception for LoopUnrollLimit, please remove
     // the flag completely from the test, also the "addFlags" at the top.
     @IR(failOn = IRNode.LOAD_VECTOR_L,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // MulVL is not implemented on NEON, so we also not have the reduction.
     // Filed: JDK-8370686
     @IR(failOn = IRNode.LOAD_VECTOR_L,
@@ -1930,13 +1930,13 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_L,   "> 0",
                   IRNode.MIN_REDUCTION_V, "> 0",
                   IRNode.MIN_VL,          "> 0"},
-        applyIfCPUFeature = {"avx512", "true"},
+        applyIfCPUFeatureOr = {"avx512", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_L,
         applyIfCPUFeatureAnd = {"avx512", "false", "avx2", "true"})
     // I think this could vectorize, but currently does not. Filed: JDK-8370671
     @IR(failOn = IRNode.LOAD_VECTOR_L,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // While MaxReductionV is implemented in NEON (see longMinSimple), MulVL is not.
     // Filed: JDK-8370686
     @IR(failOn = IRNode.LOAD_VECTOR_L,
@@ -1954,13 +1954,13 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_L,   "> 0",
                   IRNode.MAX_REDUCTION_V, "> 0",
                   IRNode.MAX_VL,          "> 0"},
-        applyIfCPUFeature = {"avx512", "true"},
+        applyIfCPUFeatureOr = {"avx512", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_L,
         applyIfCPUFeatureAnd = {"avx512", "false", "avx2", "true"})
     // I think this could vectorize, but currently does not. Filed: JDK-8370671
     @IR(failOn = IRNode.LOAD_VECTOR_L,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // While MaxReductionV is implemented in NEON (see longMaxSimple), MulVL is not.
     // Filed: JDK-8370686
     @IR(failOn = IRNode.LOAD_VECTOR_L,
@@ -1979,10 +1979,10 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_F,   "> 0",
                   IRNode.ADD_REDUCTION_V, "> 0",
                   IRNode.ADD_VF,          "= 0"},
-        applyIfCPUFeature = {"sse4.1", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "= 2"})
     @IR(failOn = IRNode.LOAD_VECTOR_F,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // I think this could vectorize, but currently does not. Filed: JDK-8370677
     // But: it is not clear that it would be profitable, given the sequential reduction.
     @IR(failOn = IRNode.LOAD_VECTOR_F,
@@ -2003,10 +2003,10 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_F,    "> 0",
                   IRNode.MUL_REDUCTION_VF, "> 0",
                   IRNode.MUL_VF,           "= 0"},
-        applyIfCPUFeature = {"sse4.1", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "= 2"})
     @IR(failOn = IRNode.LOAD_VECTOR_F,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // I think this could vectorize, but currently does not. Filed: JDK-8370677
     // But: it is not clear that it would be profitable, given the sequential reduction.
     @IR(failOn = IRNode.LOAD_VECTOR_F,
@@ -2062,10 +2062,10 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_F,   "> 0",
                   IRNode.ADD_REDUCTION_V, "> 0",
                   IRNode.ADD_VF,          "= 0"},
-        applyIfCPUFeature = {"sse4.1", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_F,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // I think this could vectorize, but currently does not. Filed: JDK-8370677
     // But: it is not clear that it would be profitable, given the sequential reduction.
     @IR(failOn = IRNode.LOAD_VECTOR_F,
@@ -2083,10 +2083,10 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_F,    "> 0",
                   IRNode.MUL_REDUCTION_VF, "> 0",
                   IRNode.MUL_VF,           "> 0"},
-        applyIfCPUFeature = {"sse4.1", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_F,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // I think this could vectorize, but currently does not. Filed: JDK-8370677
     // But: it is not clear that it would be profitable, given the sequential reduction.
     @IR(failOn = IRNode.LOAD_VECTOR_F,
@@ -2139,10 +2139,10 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_F,   "> 0",
                   IRNode.ADD_REDUCTION_V, "> 0",
                   IRNode.ADD_VF,          "> 0"},
-        applyIfCPUFeature = {"sse4.1", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_F,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // I think this could vectorize, but currently does not. Filed: JDK-8370677
     // But: it is not clear that it would be profitable, given the sequential reduction.
     @IR(failOn = IRNode.LOAD_VECTOR_F,
@@ -2160,10 +2160,10 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_F,    "> 0",
                   IRNode.MUL_REDUCTION_VF, "> 0",
                   IRNode.MUL_VF,           "> 0"},
-        applyIfCPUFeature = {"sse4.1", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_F,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // I think this could vectorize, but currently does not. Filed: JDK-8370677
     // But: it is not clear that it would be profitable, given the sequential reduction.
     @IR(failOn = IRNode.LOAD_VECTOR_F,
@@ -2216,10 +2216,10 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_D,    "> 0",
                   IRNode.ADD_REDUCTION_VD, "> 0",
                   IRNode.ADD_VD,           "= 0"},
-        applyIfCPUFeature = {"sse4.1", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "= 2"})
     @IR(failOn = IRNode.LOAD_VECTOR_D,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // I think this could vectorize, but currently does not. Filed: JDK-8370677
     // But: it is not clear that it would be profitable, given the sequential reduction.
     @IR(failOn = IRNode.LOAD_VECTOR_D,
@@ -2240,10 +2240,10 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_D,    "> 0",
                   IRNode.MUL_REDUCTION_VD, "> 0",
                   IRNode.MUL_VD,           "= 0"},
-        applyIfCPUFeature = {"sse4.1", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "= 2"})
     @IR(failOn = IRNode.LOAD_VECTOR_D,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // I think this could vectorize, but currently does not. Filed: JDK-8370677
     // But: it is not clear that it would be profitable, given the sequential reduction.
     @IR(failOn = IRNode.LOAD_VECTOR_D,
@@ -2299,10 +2299,10 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_D,   "> 0",
                   IRNode.ADD_REDUCTION_V, "> 0",
                   IRNode.ADD_VD,          "= 0"},
-        applyIfCPUFeature = {"sse4.1", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_D,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // I think this could vectorize, but currently does not. Filed: JDK-8370677
     // But: it is not clear that it would be profitable, given the sequential reduction.
     @IR(failOn = IRNode.LOAD_VECTOR_D,
@@ -2320,10 +2320,10 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_D,    "> 0",
                   IRNode.MUL_REDUCTION_VD, "> 0",
                   IRNode.MUL_VD,           "> 0"},
-        applyIfCPUFeature = {"sse4.1", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_D,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // I think this could vectorize, but currently does not. Filed: JDK-8370677
     // But: it is not clear that it would be profitable, given the sequential reduction.
     @IR(failOn = IRNode.LOAD_VECTOR_D,
@@ -2376,10 +2376,10 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_D,   "> 0",
                   IRNode.ADD_REDUCTION_V, "> 0",
                   IRNode.ADD_VD,          "> 0"},
-        applyIfCPUFeature = {"sse4.1", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_D,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // I think this could vectorize, but currently does not. Filed: JDK-8370677
     // But: it is not clear that it would be profitable, given the sequential reduction.
     @IR(failOn = IRNode.LOAD_VECTOR_D,
@@ -2397,10 +2397,10 @@ public class TestReductions {
     @IR(counts = {IRNode.LOAD_VECTOR_D,    "> 0",
                   IRNode.MUL_REDUCTION_VD, "> 0",
                   IRNode.MUL_VD,           "> 0"},
-        applyIfCPUFeature = {"sse4.1", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "sve", "true"},
         applyIf = {"AutoVectorizationOverrideProfitability", "> 0"})
     @IR(failOn = IRNode.LOAD_VECTOR_D,
-        applyIfCPUFeatureAnd = {"asimd", "true"})
+        applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     // I think this could vectorize, but currently does not. Filed: JDK-8370677
     // But: it is not clear that it would be profitable, given the sequential reduction.
     @IR(failOn = IRNode.LOAD_VECTOR_D,

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorOperations.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorOperations.java
@@ -24,7 +24,7 @@
 
 /**
 * @test
-* @bug 8346236
+* @bug 8346236 8381617
 * @summary Auto-vectorization support for various Float16 operations
 * @modules jdk.incubator.vector
 * @library /test/lib /
@@ -92,7 +92,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(50)
     @IR(counts = {IRNode.ADD_VHF, " >0 "},
-        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true", "sve", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     @IR(counts = {IRNode.ADD_VHF, " >0 "},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void vectorAddFloat16() {
@@ -113,7 +113,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(50)
     @IR(counts = {IRNode.SUB_VHF, " >0 "},
-        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true", "sve", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     @IR(counts = {IRNode.SUB_VHF, " >0 "},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void vectorSubFloat16() {
@@ -134,7 +134,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(50)
     @IR(counts = {IRNode.MUL_VHF, " >0 "},
-        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true", "sve", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     @IR(counts = {IRNode.MUL_VHF, " >0 "},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void vectorMulFloat16() {
@@ -154,7 +154,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(50)
     @IR(counts = {IRNode.DIV_VHF, " >0 "},
-        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true", "sve", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     @IR(counts = {IRNode.DIV_VHF, " >0 "},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void vectorDivFloat16() {
@@ -174,7 +174,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(50)
     @IR(counts = {IRNode.MIN_VHF, " >0 "},
-        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true", "sve", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     @IR(counts = {IRNode.MIN_VHF, " >0 "},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void vectorMinFloat16() {
@@ -194,7 +194,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(50)
     @IR(counts = {IRNode.MAX_VHF, " >0 "},
-        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true", "sve", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     @IR(counts = {IRNode.MAX_VHF, " >0 "},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void vectorMaxFloat16() {
@@ -214,7 +214,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(50)
     @IR(counts = {IRNode.SQRT_VHF, " >0 "},
-        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true", "sve", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     @IR(counts = {IRNode.SQRT_VHF, " >0 "},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void vectorSqrtFloat16() {
@@ -234,7 +234,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(50)
     @IR(counts = {IRNode.FMA_VHF, " >0 "},
-        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true", "sve", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     @IR(counts = {IRNode.FMA_VHF, " >0 "},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void vectorFmaFloat16() {
@@ -256,7 +256,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(50)
     @IR(counts = {IRNode.FMA_VHF, " >0 "},
-        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true", "sve", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     @IR(counts = {IRNode.FMA_VHF, " >0 "},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void vectorFmaFloat16ScalarMixedConstants() {
@@ -279,7 +279,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(50)
     @IR(counts = {IRNode.FMA_VHF, " >0 "},
-        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true", "sve", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     @IR(counts = {IRNode.FMA_VHF, " >0 "},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void vectorFmaFloat16MixedConstants() {
@@ -302,7 +302,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(50)
     @IR(counts = {IRNode.FMA_VHF, " 0 "},
-        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true", "sve", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     @IR(counts = {IRNode.FMA_VHF, " 0 "},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void vectorFmaFloat16AllConstants() {
@@ -329,7 +329,7 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(50)
     @IR(counts = {IRNode.ADD_VHF, " >0 "},
-        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true", "sve", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     @IR(counts = {IRNode.ADD_VHF, " >0 "},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void vectorAddConstInputFloat16() {


### PR DESCRIPTION
The only diff between tip and jdk26u is the missing extra bug IDs. Otherwise this patch applies cleanly.

```diff
 * @test id=vanilla
- * @bug 8340093
+ * @bug 8340093 8342095 8381617
 * @summary Test vectorization of reduction loops.
 * @library /test/lib /
 * @run driver compiler.loopopts.superword.TestReductions P1
 */

/*
 * @test id=force-vectorization
- * @bug 8340093
+ * @bug 8340093 8342095 8381617
 * @summary Test vectorization of reduction loops.
 * @library /test/lib /
 * @run driver compiler.loopopts.superword.TestReductions P2
 */
```



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] [JDK-8381617](https://bugs.openjdk.org/browse/JDK-8381617) needs maintainer approval
- \[ \] [JDK-8385425](https://bugs.openjdk.org/browse/JDK-8385425) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issues
 * [JDK-8381617](https://bugs.openjdk.org/browse/JDK-8381617): vm_version_windows_aarch64.cpp: PF_ARM_SVE_INSTRUCTIONS_AVAILABLE undeclared identifier (**Bug** - P4 - Requested)
 * [JDK-8385425](https://bugs.openjdk.org/browse/JDK-8385425): AArch64: Comment re set_and_get_current_sve_vector_length() is misleading (**Enhancement** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) Review applies to [f5c35bc8](https://git.openjdk.org/jdk26u/pull/205/files/f5c35bc8709848006a914c2b4f21484152ac2b2d)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/205/head:pull/205` \
`$ git checkout pull/205`

Update a local copy of the PR: \
`$ git checkout pull/205` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 205`

View PR using the GUI difftool: \
`$ git pr show -t 205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/205.diff">https://git.openjdk.org/jdk26u/pull/205.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/205#issuecomment-4502916279)
</details>
