### PR TITLE
8381851: handleMessage use uninitialized struct

### DIFF
--- a/src/jdk.sctp/unix/native/libsctp/SctpChannelImpl.c
+++ b/src/jdk.sctp/unix/native/libsctp/SctpChannelImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -389,7 +389,7 @@ void handleMessage
   (JNIEnv* env, jobject resultContainerObj, struct msghdr* msg,int read,
    jboolean isEOR, struct sockaddr* sap) {
     jobject isa, resultObj;
-    struct controlData cdata[1];
+    struct controlData cdata[1] = {0};
 
     if (read == 0) {
         /* we reached EOF */


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [66ae5508](https://github.com/openjdk/jdk/commit/66ae5508998aeacde2848dcf934539f6b0fd72d6) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 21 May 2026 and was reviewed by Jaikiran Pai.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8381851](https://bugs.openjdk.org/browse/JDK-8381851) needs maintainer approval

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8381851](https://bugs.openjdk.org/browse/JDK-8381851): handleMessage use uninitialized struct (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/206/head:pull/206` \
`$ git checkout pull/206`

Update a local copy of the PR: \
`$ git checkout pull/206` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/206/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 206`

View PR using the GUI difftool: \
`$ git pr show -t 206`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/206.diff">https://git.openjdk.org/jdk26u/pull/206.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/206#issuecomment-4508614479)
</details>
