### PR TITLE
8385665: Address possible oversized errors in Math.pow

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntimeTrans.cpp
+++ b/src/hotspot/share/runtime/sharedRuntimeTrans.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -442,8 +442,8 @@ bp[] = {1.0, 1.5,},
         cp_h  =  9.61796700954437255859e-01, /* 0x3FEEC709, 0xE0000000 =(float)cp */
         cp_l  = -7.02846165095275826516e-09, /* 0xBE3E2FE0, 0x145B01F5 =tail of cp_h*/
         ivln2    =  1.44269504088896338700e+00, /* 0x3FF71547, 0x652B82FE =1/ln2 */
-        ivln2_h  =  1.44269502162933349609e+00, /* 0x3FF71547, 0x60000000 =24b 1/ln2*/
-        ivln2_l  =  1.92596299112661746887e-08; /* 0x3E54AE0B, 0xF85DDF44 =1/ln2 tail*/
+        ivln2_h  =  1.4426946640014648438, /* 0x3FF71547, 0x00000000 =21b 1/ln2*/
+        ivln2_l  =  3.7688749856360991145e-07; /* 0x3E994AE0, 0xBF85DDF4 =1/ln2 tail*/
 
 ATTRIBUTE_NO_UBSAN
 static double __ieee754_pow(double x, double y) {

--- a/src/java.base/share/classes/java/lang/FdLibm.java
+++ b/src/java.base/share/classes/java/lang/FdLibm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2125,6 +2125,11 @@ final class FdLibm {
         }
 
         public static double compute(final double x, final double y) {
+            return compute(x, y, true);
+        }
+
+        public static double compute(final double x, final double y,
+                                     boolean fdlibm53compat) {
             double z;
             double r, s, t, u, v, w;
             int i, j, k, n;
@@ -2207,8 +2212,15 @@ final class FdLibm {
             // |y| is huge
             if (y_abs > 0x1.00000_ffff_ffffp31) { // if |y| > ~2**31
                 final double INV_LN2   =  0x1.7154_7652_b82fep0;   //  1.44269504088896338700e+00 = 1/ln2
-                final double INV_LN2_H =  0x1.715476p0;            //  1.44269502162933349609e+00 = 24 bits of 1/ln2
-                final double INV_LN2_L =  0x1.4ae0_bf85_ddf44p-26; //  1.92596299112661746887e-08 = 1/ln2 tail
+                double INV_LN2_H;
+                double INV_LN2_L;
+                if (fdlibm53compat) {
+                    INV_LN2_H =  0x1.715476p0;            //  1.44269502162933349609e+00 = 24 bits of 1/ln2
+                    INV_LN2_L =  0x1.4ae0_bf85_ddf44p-26; //  1.92596299112661746887e-08 = 1/ln2 tail
+                } else {
+                    INV_LN2_H =  0x1.7154_7p+0;           //  1.4426946640014648438      = 21 bits of 1/ln2
+                    INV_LN2_L =  0x1.94ae_0bf8_5ddf4p-22; //  3.7688749856360991145e-07  = 1/ln2 tail
+                }
 
                 // Over/underflow if x is not close to one
                 if (x_abs < 0x1.fffff_0000_0000p-1) // |x| < ~0.9999995231628418

--- a/src/java.base/share/classes/java/lang/Math.java
+++ b/src/java.base/share/classes/java/lang/Math.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -752,7 +752,7 @@ public final class Math {
      */
     @IntrinsicCandidate
     public static double pow(double a, double b) {
-        return StrictMath.pow(a, b); // default impl. delegates to StrictMath
+        return FdLibm.Pow.compute(a, b, false);
     }
 
     /**

--- a/test/jdk/java/lang/Math/PowLargeExpTests.java
+++ b/test/jdk/java/lang/Math/PowLargeExpTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8385665
+ * @summary Tests for Math.pow with a large exponent
+ * @build Tests
+ * @build PowLargeExpTests
+ * @run main PowLargeExpTests
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:ControlIntrinsic=-_dpow
+ *                    PowLargeExpTests
+ */
+
+public class PowLargeExpTests {
+    private PowLargeExpTests(){}
+
+    public static void main(String... args) {
+        int failures = 0;
+        // Probe arguments where stock FDLIBM 5.3 has a large error.
+        double[][] testCases = {
+            // {x, y, expected pow(x, y)}
+            {
+                0x1.000002c5e2e99p+0,   // |x| > 1
+                0x1.c9eee35374af6p+31,  // |y| huge
+                0x1.ffffe0bc9e399p+915
+            },
+
+            {
+                0x1.fffff4e900013p-1,   // |x| < 1
+                0x1.0000100000001p+31,  // |y| huge
+                0x0.421378008b246p-1022
+            },
+
+        };
+
+        for (double[] testCase: testCases) {
+            failures += testPowCase(testCase[0], testCase[1], testCase[2]);
+        }
+
+        if (failures > 0) {
+            System.err.println("Testing pow incurred " + failures + " failures.");
+            throw new RuntimeException();
+        }
+    }
+
+    private static int testPowCase(double input1, double input2, double expected) {
+        int failures = 0;
+        // With the general quality of implementation requirements of
+        // the pow method, the results of Math.pow(x, y) should be
+        // within two ulps of the expected reference value. This could
+        // be narrowed to one ulp if it was known if the reference
+        // value was rounded up or down.
+        failures += Tests.testUlpDiff("Math.pow(double)", input1, input2,
+                                      Math::pow, expected, 2.0);
+        return failures;
+    }
+}


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8385665](https://bugs.openjdk.org/browse/JDK-8385665) needs maintainer approval

### Issue
 * [JDK-8385665](https://bugs.openjdk.org/browse/JDK-8385665): Address possible oversized errors in Math.pow (**Bug** - P4 - Approved)


### Reviewers
 * [Rob McKenna](https://openjdk.org/census#robm) (@robm-openjdk - **Reviewer**)
 * [Fredrik Bredberg](https://openjdk.org/census#fbredberg) (@fbredber - no project role)

### Contributors
 * Anton Artemov `<aartemov@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/210/head:pull/210` \
`$ git checkout pull/210`

Update a local copy of the PR: \
`$ git checkout pull/210` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 210`

View PR using the GUI difftool: \
`$ git pr show -t 210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/210.diff">https://git.openjdk.org/jdk26u/pull/210.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/210#issuecomment-4609300534)
</details>
