### PR TITLE
8383867: File.getCanonicalPath drops backslash from UNC path with directory junctions

### DIFF
--- a/src/java.base/windows/native/libjava/canonicalize_md.c
+++ b/src/java.base/windows/native/libjava/canonicalize_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -181,10 +181,12 @@ WCHAR* getFinalPath(WCHAR* path, WCHAR* finalPath, DWORD size)
                 int isUnc = (finalPath[4] == L'U' &&
                              finalPath[5] == L'N' &&
                              finalPath[6] == L'C');
+                // keep leading double backslashes in case of UNC
+                const int startIdx = (isUnc) ? 1 : 0;
                 int prefixLen = (isUnc) ? 7 : 4;
                 // the amount to copy includes terminator
                 int amountToCopy = len - prefixLen + 1;
-                wmemmove(finalPath, finalPath + prefixLen, amountToCopy);
+                wmemmove(finalPath + startIdx, finalPath + prefixLen, amountToCopy);
             }
 
             return finalPath;

--- a/test/jdk/java/io/File/GetCanonicalPath.java
+++ b/test/jdk/java/io/File/GetCanonicalPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4899022 8003887 8355342
+ * @bug 4899022 8003887 8355342 8383867
  * @summary Look for erroneous representation of drive letter
  * @run junit GetCanonicalPath
  */
@@ -148,7 +148,14 @@ public class GetCanonicalPath {
         Runtime rt = Runtime.getRuntime();
         String share =
             "\\\\localhost\\" + cwd.charAt(0) + "$" + cwd.substring(2);
+        String junctionName = "tmpDir";
         try {
+            // create directory junction
+            Path tmpDir = Files.createTempDirectory(junctionName);
+            String tmpDirLink = cwd + "\\" + junctionName;
+            Process pmklink = rt.exec(new String[] {"cmd", "/c", "mklink", "/J", tmpDirLink, tmpDir.toString()});
+            assertEquals(0, pmklink.waitFor());
+
             Process p = rt.exec(new String[] {"net", "use", drive + ":", share});
             assertEquals(0, p.waitFor());
         } catch (InterruptedException x) {
@@ -157,13 +164,26 @@ public class GetCanonicalPath {
 
         // check that the canonical path name and its content are as expected
         try {
-            final String filename = "file.txt";
-            final String text = "This is some text";
-            Files.writeString(Path.of(share, filename), text);
-            File file = new File(drive + ":\\" + filename);
-            String canonicalPath = file.getCanonicalPath();
-            assertEquals(drive + ":\\" + filename, canonicalPath);
-            assertEquals(text, Files.readString(Path.of(canonicalPath)));
+            // use drive letter
+            {
+                final String filename = "file.txt";
+                final String text = "This is some text";
+                Files.writeString(Path.of(share, filename), text);
+                File file = new File(drive + ":\\" + filename);
+                String canonicalPath = file.getCanonicalPath();
+                assertEquals(drive + ":\\" + filename, canonicalPath);
+                assertEquals(text, Files.readString(Path.of(canonicalPath)));
+            }
+            // use reparse point (directory junction)
+            {
+                final String filename = junctionName + "\\file.txt";
+                final String text = "This is some text";
+                Files.writeString(Path.of(share, filename), text);
+                File file = new File(drive + ":\\" + filename);
+                String canonicalPath = file.getCanonicalPath();
+                assertTrue(canonicalPath.startsWith("\\\\localhost\\"));
+                assertEquals(text, Files.readString(Path.of(canonicalPath)));
+            }
         } finally {
             try {
                 Process p = rt.exec(new String[] {"net", "use", drive + ":", "/Delete"});


### PR DESCRIPTION
This is the clean backport of [JDK-8383867](https://bugs.openjdk.org/browse/JDK-8383867) to jdk26u, as jdk26 is affected by the problem "File.getCanonicalPath drops backslash from UNC path with directory junctions".

The added test fails before the fix and passes ok with the fix.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8383867](https://bugs.openjdk.org/browse/JDK-8383867) needs maintainer approval

### Issue
 * [JDK-8383867](https://bugs.openjdk.org/browse/JDK-8383867): File.getCanonicalPath drops backslash from UNC path with directory junctions (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/211/head:pull/211` \
`$ git checkout pull/211`

Update a local copy of the PR: \
`$ git checkout pull/211` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/211/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 211`

View PR using the GUI difftool: \
`$ git pr show -t 211`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/211.diff">https://git.openjdk.org/jdk26u/pull/211.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/211#issuecomment-4613456783)
</details>
