### PR TITLE
8388284: [s390] resolve_jobject uses wrong branch condition after tmll

### DIFF
--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -116,7 +116,7 @@ void BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value, 
   __ z_bre(done);          // Use null result as-is.
 
   __ z_tmll(value, JNIHandles::tag_mask);
-  __ z_btrue(tagged); // not zero
+  __ branch_optimized(Assembler::bcondNotAllZero, tagged); // not zero
 
   // Resolve Local handle
   __ access_load_at(T_OBJECT, IN_NATIVE | AS_RAW, Address(value, 0), value, tmp1, tmp2);
@@ -124,7 +124,7 @@ void BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value, 
 
   __ bind(tagged);
   __ testbit(value, exact_log2(JNIHandles::TypeTag::weak_global)); // test for weak tag
-  __ z_btrue(weak_tag);
+  __ branch_optimized(Assembler::bcondNotAllZero, weak_tag);
 
   // resolve global handle
   __ access_load_at(T_OBJECT, IN_NATIVE, Address(value, -JNIHandles::TypeTag::global), value, tmp1, tmp2);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [c5c366ad](https://github.com/openjdk/jdk/commit/c5c366ad0cfe33361b0c30597bc71beb4770db09) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Harshit Dhiman on 17 Jul 2026 and was reviewed by Amit Kumar and Andrew Haley.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8388284](https://bugs.openjdk.org/browse/JDK-8388284) needs maintainer approval

### Issue
 * [JDK-8388284](https://bugs.openjdk.org/browse/JDK-8388284): [s390] resolve_jobject uses wrong branch condition after tmll (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk26u.git pull/217/head:pull/217` \
`$ git checkout pull/217`

Update a local copy of the PR: \
`$ git checkout pull/217` \
`$ git pull https://git.openjdk.org/jdk26u.git pull/217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 217`

View PR using the GUI difftool: \
`$ git pr show -t 217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk26u/pull/217.diff">https://git.openjdk.org/jdk26u/pull/217.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk26u/pull/217#issuecomment-5066930628)
</details>
